### PR TITLE
Publish types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,17 @@
   "license": "UNLICENSED",
   "author": "CrowdStrike UX Team",
   "exports": {
-    ".": "./dist/index.js",
-    "./*": "./dist/*"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
   },
   "directories": {},
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,11 @@
     "module": "ESNext",
     "target": "ESNext",
 
+    // Output settings
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+
     // Features
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
@@ -31,5 +36,5 @@
     // This addon does not allow JavaScript
     "allowJs": false
   },
-  "include": ["config/rollup.config.ts", "src/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
This will also emit `*.d.ts` declaration files for TypeScript consumers. Note that the `exports` limits importing from only the root (index) module, we won't allow imports from e.g. `@crowdstrike/foundry-js/apis/incidents/bridge`. Rollup is currently bundling everything into a single `index.js` anyway, but the declaration files are emitted by TS in the same folder structure as in `src`. So anything public should be reexported from `index.ts`.