### PR TITLE
Refactor API

### DIFF
--- a/src/apis/public-api.ts
+++ b/src/apis/public-api.ts
@@ -13,22 +13,19 @@
  *
  **/
 
-import { setupApiBridgeInstance } from '../bridge';
 import { IncidentsApiBridge } from './incidents/bridge';
 import { RemoteResponseApiBridge } from './remote-response/bridge';
 
-export const publicApis = {
-  incidents: () => {
-    return setupApiBridgeInstance<IncidentsApiBridge>(
-      IncidentsApiBridge,
-      (bridge) => new IncidentsApiBridge(bridge),
-    );
-  },
+import type { Bridge } from '../bridge';
 
-  remoteResponse: () => {
-    return setupApiBridgeInstance<RemoteResponseApiBridge>(
-      RemoteResponseApiBridge,
-      (bridge) => new RemoteResponseApiBridge(bridge),
-    );
-  },
-};
+export default class FalconPublicApis {
+  bridge: Bridge;
+  incidents: IncidentsApiBridge;
+  remoteResponse: RemoteResponseApiBridge;
+
+  constructor(bridge: Bridge) {
+    this.bridge = bridge;
+    this.incidents = new IncidentsApiBridge(bridge);
+    this.remoteResponse = new RemoteResponseApiBridge(bridge);
+  }
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -18,7 +18,10 @@ interface PostMessageParams {
 }
 
 export class Bridge {
-  private pendingMessages = new Map<CommunicationMessageId, (result: never) => void>();
+  private pendingMessages = new Map<
+    CommunicationMessageId,
+    (result: never) => void
+  >();
 
   private callbackHandlers: ((data: any) => void)[] = [];
 
@@ -33,7 +36,10 @@ export class Bridge {
   }
 
   // TODO: what to do if we can't resolve back the promise?
-  async postMessage<T>(payload: Message, { type }: PostMessageParams = {}): Promise<T> {
+  async postMessage<T>(
+    payload: Message,
+    { type }: PostMessageParams = {}
+  ): Promise<T> {
     return new Promise((resolve) => {
       const __csMessageId__ = uuidv4();
 
@@ -48,7 +54,7 @@ export class Bridge {
             version: VERSION,
           },
         },
-        this.targetOrigin,
+        this.targetOrigin
       );
     });
   }
@@ -59,7 +65,9 @@ export class Bridge {
         this.callbackHandlers.push(callback);
       },
       off: (callback: (data: any) => void) => {
-        this.callbackHandlers = this.callbackHandlers.filter((handler) => handler !== callback);
+        this.callbackHandlers = this.callbackHandlers.filter(
+          (handler) => handler !== callback
+        );
       },
     };
   }
@@ -88,21 +96,6 @@ export class Bridge {
 }
 
 const cache = new WeakMap();
-
-export function setupApiBridgeInstance<T>(
-  bridgeClass: object,
-  initializationCallback: (bridge: Bridge) => T,
-): T {
-  if (!cache.has(Bridge)) {
-    cache.set(Bridge, new Bridge());
-  }
-
-  if (!cache.has(bridgeClass)) {
-    cache.set(bridgeClass, initializationCallback(cache.get(Bridge)));
-  }
-
-  return cache.get(bridgeClass) as T;
-}
 
 export function getBridgeInstance(): Bridge {
   if (!cache.has(Bridge)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { publicApis } from './apis/public-api';
+import FalconPublicApis from 'apis/public-api';
+
 import { PLATFORM_EVENTS } from './apis/types';
 import { getBridgeInstance } from './bridge';
 
@@ -9,10 +10,10 @@ interface ReadyEventData {
   };
 }
 
-export const falcon = {
-  bridge: getBridgeInstance(),
+export default class FalconApi extends FalconPublicApis {
+  constructor() {
+    const bridge = getBridgeInstance();
 
-  init() {
     const handleReadyEvent = (data: ReadyEventData) => {
       if (data.payload.name === PLATFORM_EVENTS.READY) {
         this.bridge.message.off(handleReadyEvent);
@@ -22,8 +23,8 @@ export const falcon = {
       }
     };
 
-    this.bridge.message.on(handleReadyEvent);
-  },
+    bridge.message.on(handleReadyEvent);
 
-  ...publicApis,
-};
+    super(bridge);
+  }
+}


### PR DESCRIPTION
This is changing the API of `foundry-js` slightly:
* export a proper (typed) class instead of a POJO with `init()`
* use a default export, as I believe we can expect this to be the only entrypoint for users, right?
* as we cannot splat `...publicApis` on a class, this is refactoring the setup of API specific bridges a bit:
  * as we need some explicit instantiation in the class, we can pass `bridge` directly, instead of relying on the previous indirection of `setupApiBridgeInstance`
  * with this the WeakMap based lookups of API bridges can be dropped. Those don't really have to be singletons, they don't hold important state. Still good to have the main bridge a global singleton, as we don't want multiple pieces that send `postMessage`
* we use `public-api.ts` as a base class, containing all the APIs that we can auto-generate