### PR TITLE
Add `connect()` API

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "start": "yarn build:js --watch"
   },
   "dependencies": {
+    "typescript-memoize": "^1.1.1",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/src/apis/public-api.ts
+++ b/src/apis/public-api.ts
@@ -13,19 +13,33 @@
  *
  **/
 
+import { Memoize } from 'typescript-memoize';
+
 import { IncidentsApiBridge } from './incidents/bridge';
 import { RemoteResponseApiBridge } from './remote-response/bridge';
 
 import type { Bridge } from '../bridge';
+import { assertConnection } from './utils';
 
 export default class FalconPublicApis {
+  isConnected = false;
   bridge: Bridge;
-  incidents: IncidentsApiBridge;
-  remoteResponse: RemoteResponseApiBridge;
+
+  @Memoize()
+  get incidents(): IncidentsApiBridge {
+    assertConnection(this);
+
+    return new IncidentsApiBridge(this.bridge);
+  }
+
+  @Memoize()
+  get remoteResponse(): RemoteResponseApiBridge {
+    assertConnection(this);
+
+    return new RemoteResponseApiBridge(this.bridge);
+  }
 
   constructor(bridge: Bridge) {
     this.bridge = bridge;
-    this.incidents = new IncidentsApiBridge(bridge);
-    this.remoteResponse = new RemoteResponseApiBridge(bridge);
   }
 }

--- a/src/apis/utils.ts
+++ b/src/apis/utils.ts
@@ -1,0 +1,9 @@
+import FalconPublicApis from './public-api';
+
+export function assertConnection(falcon: FalconPublicApis) {
+  if (!falcon.isConnected) {
+    throw new Error(
+      'You cannot call this API before having established a connection to the host!'
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,6 +321,11 @@ tslib@2.5.0, tslib@^2.1.0:
   resolved "https://artifactory.cicd.dc/artifactory/api/npm/product-platform-ui-npm-prod-virtual/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
+typescript-memoize@^1.1.1:
+  version "1.1.1"
+  resolved "https://artifactory.cicd.dc/artifactory/api/npm/product-platform-ui-npm-prod-virtual/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
+  integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
+
 typescript@5.0.2:
   version "5.0.2"
   resolved "https://artifactory.cicd.dc/artifactory/api/npm/product-platform-ui-npm-prod-virtual/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"


### PR DESCRIPTION
This explicitly creates the connection to the host, and allows the client to wait for the connection to be established before calling other APIs or rendering stuff.

Supersedes #2