### PR TITLE
Reverse order of "ready" handshake

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepublishOnly": "yarn build",
-    "start": "yarn build:js --watch",
+    "start": "yarn build --watch",
     "test": "vitest"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,43 +2,14 @@ import FalconPublicApis from './apis/public-api';
 
 import { PLATFORM_EVENTS } from './apis/types';
 
-interface ReadyEventData {
-  payload: {
-    name: 'Ready';
-    origin: string;
-  };
-}
-
-const CONNECTION_TIMEOUT = process.env.VITEST ? 1 : 5000;
-
 export default class FalconApi extends FalconPublicApis {
   async connect(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      const timeoutTimer = setTimeout(() => {
-        this.bridge.message.off(handleReadyEvent);
-        reject(
-          new Error(
-            `Connection to foundry host timed out after ${CONNECTION_TIMEOUT}ms!`
-          )
-        );
-      }, CONNECTION_TIMEOUT);
-
-      const handleReadyEvent = (data: ReadyEventData) => {
-        if (data.payload.name === PLATFORM_EVENTS.READY) {
-          this.bridge.message.off(handleReadyEvent);
-          clearTimeout(timeoutTimer);
-
-          this.bridge.setOrigin(data.payload?.origin);
-          this.bridge.postMessage({ type: PLATFORM_EVENTS.READY });
-
-          this.isConnected = true;
-
-          resolve();
-        }
-      };
-
-      this.bridge.message.on(handleReadyEvent);
+    const data: any = await this.bridge.postMessage({
+      type: PLATFORM_EVENTS.READY,
     });
+
+    this.bridge.setOrigin(data.origin);
+    this.isConnected = true;
   }
 
   destroy() {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,12 +2,15 @@ import FalconApi from '../src';
 import { PLATFORM_EVENTS } from '../src/apis/types';
 
 export async function connectApi(api: FalconApi) {
-  const promise = api.connect();
+  // simulate ready answer coming back from main thread
+  window.parent.addEventListener('message', (message) => {
+    window.postMessage({
+      payload: { name: PLATFORM_EVENTS },
+      meta: { __csMessageId__: message.data.meta.__csMessageId__ },
+    });
+  });
 
-  // simulate ready event coming from main thread
-  window.postMessage({ payload: { name: PLATFORM_EVENTS.READY } });
-
-  await promise;
+  return api.connect();
 }
 
 export const uuidV4Regex =

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,11 +21,17 @@ test('it has a bridge', () => {
 });
 
 test('it can connect to main thread', async () => {
-  expect(api.isConnected).toEqual(false);
-  const promise = api.connect();
+  // simulate ready answer coming back from main thread
+  window.parent.addEventListener('message', (message) => {
+    window.postMessage({
+      payload: { name: PLATFORM_EVENTS, origin: 'www.example.com' },
+      meta: { __csMessageId__: message.data.meta.__csMessageId__ },
+    });
+  });
 
-  // simulate ready event coming from main thread
-  window.postMessage({ payload: { name: PLATFORM_EVENTS.READY } });
+  expect(api.isConnected).toEqual(false);
+
+  const promise = api.connect();
 
   await promise;
   expect(api.isConnected).toEqual(true);


### PR DESCRIPTION
Instead of making the main thread (falcon-console) send the first "ready" postmessage event (which assumes the UI extension is already listening for at this point, which might not be true always), we can reverse the order and let the UI extension make the first request (by calling `await api.connect()`)