### PR TITLE
Setup publish to dist-branch

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,18 @@
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: yarn build
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will push output of `npm pack` to the `dist` folder, on every push to `main`. This will allow us to use the latest version even before cutting a new release. This is needed because we have a build step, so we cannot just point our `package.json` to the github repo with the source files directly.