### PR TITLE
Fix type exports in package.json

### DIFF
--- a/.changeset/five-dots-dance.md
+++ b/.changeset/five-dots-dance.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/foundry-js': patch
+---
+
+Fix package.json exports for API types
+
+For types, we want to allow importing from e.g. `/apis/workflows`, which should map to `/dist/apis/workflows/index.d.ts` (note the implicit index module). For real runtime imports, we still only allow importing from index, i.e. `@crowdstrike/foundry-js`.

--- a/package.json
+++ b/package.json
@@ -12,11 +12,15 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./apis/*": {
+      "types": "./dist/apis/*/index.d.ts"
     }
   },
   "typesVersions": {
     "*": {
       "*": [
+        "dist/*/index.d.ts",
         "dist/*"
       ]
     }


### PR DESCRIPTION
For types, we want to allow importing from e.g. `/apis/workflows`, which should map to `/dist/apis/workflows/index.d.ts` (note the implicit index module). For real runtime imports, we still only allow importing from index, i.e. `@crowdstrike/foundry-js`.