### PR TITLE
feat add new plugins and loggins apis

### DIFF
--- a/.changeset/thirty-buses-itch.md
+++ b/.changeset/thirty-buses-itch.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/foundry-js': minor
+---
+
+Adding new methods to plugins and logging apis

--- a/src/apis/loggingapi/index.ts
+++ b/src/apis/loggingapi/index.ts
@@ -49,6 +49,23 @@ export interface GetEntitiesSavedSearchesExecuteV1RequestMessage
   method: 'getEntitiesSavedSearchesExecuteV1';
 }
 
+// types for getEntitiesSavedSearchesV1
+
+export interface GetEntitiesSavedSearchesV1QueryParams extends BaseUrlParams {
+  ids: QueryParam;
+}
+
+export type GetEntitiesSavedSearchesV1ApiResponse = ApiResponsePayload;
+
+export type GetEntitiesSavedSearchesV1ResponseMessage =
+  BaseApiResponseMessage<GetEntitiesSavedSearchesV1ApiResponse>;
+
+export interface GetEntitiesSavedSearchesV1RequestMessage
+  extends BaseApiRequestMessage<GetEntitiesSavedSearchesV1QueryParams> {
+  api: LoggingapiRequestApi;
+  method: 'getEntitiesSavedSearchesV1';
+}
+
 // types for postEntitiesSavedSearchesDynamicExecuteV1
 
 export interface PostEntitiesSavedSearchesDynamicExecuteV1QueryParams
@@ -124,10 +141,12 @@ export interface PostEntitiesSavedSearchesIngestV1RequestMessage
 
 export type LoggingapiApiRequestMessage =
   | GetEntitiesSavedSearchesExecuteV1RequestMessage
+  | GetEntitiesSavedSearchesV1RequestMessage
   | PostEntitiesSavedSearchesExecuteV1RequestMessage;
 
 export type LoggingapiApiResponseMessage =
   | GetEntitiesSavedSearchesExecuteV1ResponseMessage
+  | GetEntitiesSavedSearchesV1ResponseMessage
   | PostEntitiesSavedSearchesExecuteV1ResponseMessage;
 
 export class LoggingapiApiBridge {
@@ -148,6 +167,21 @@ export class LoggingapiApiBridge {
       type: 'api',
       api: 'loggingapi',
       method: 'getEntitiesSavedSearchesExecuteV1',
+      payload: {
+        params: urlParams,
+      },
+    };
+
+    return this.bridge.postMessage(message);
+  }
+
+  async getEntitiesSavedSearchesV1(
+    urlParams: GetEntitiesSavedSearchesV1QueryParams,
+  ): Promise<GetEntitiesSavedSearchesV1ApiResponse> {
+    const message: GetEntitiesSavedSearchesV1RequestMessage = {
+      type: 'api',
+      api: 'loggingapi',
+      method: 'getEntitiesSavedSearchesV1',
       payload: {
         params: urlParams,
       },

--- a/src/apis/plugins/index.ts
+++ b/src/apis/plugins/index.ts
@@ -44,6 +44,23 @@ export interface GetEntitiesConfigsV1RequestMessage
   method: 'getEntitiesConfigsV1';
 }
 
+// types for getEntitiesDefinitionsV1
+
+export interface GetEntitiesDefinitionsV1QueryParams extends BaseUrlParams {
+  ids: QueryParam;
+}
+
+export type GetEntitiesDefinitionsV1ApiResponse = ApiResponsePayload;
+
+export type GetEntitiesDefinitionsV1ResponseMessage =
+  BaseApiResponseMessage<GetEntitiesDefinitionsV1ApiResponse>;
+
+export interface GetEntitiesDefinitionsV1RequestMessage
+  extends BaseApiRequestMessage<GetEntitiesDefinitionsV1QueryParams> {
+  api: PluginsRequestApi;
+  method: 'getEntitiesDefinitionsV1';
+}
+
 // types for postEntitiesExecuteDraftV1
 
 export type PostEntitiesExecuteDraftV1QueryParams = BaseUrlParams;
@@ -88,11 +105,13 @@ export interface PostEntitiesExecuteV1RequestMessage
 
 export type PluginsApiRequestMessage =
   | GetEntitiesConfigsV1RequestMessage
+  | GetEntitiesDefinitionsV1RequestMessage
   | PostEntitiesExecuteDraftV1RequestMessage
   | PostEntitiesExecuteV1RequestMessage;
 
 export type PluginsApiResponseMessage =
   | GetEntitiesConfigsV1ResponseMessage
+  | GetEntitiesDefinitionsV1ResponseMessage
   | PostEntitiesExecuteDraftV1ResponseMessage
   | PostEntitiesExecuteV1ResponseMessage;
 
@@ -114,6 +133,21 @@ export class PluginsApiBridge {
       type: 'api',
       api: 'plugins',
       method: 'getEntitiesConfigsV1',
+      payload: {
+        params: urlParams,
+      },
+    };
+
+    return this.bridge.postMessage(message);
+  }
+
+  async getEntitiesDefinitionsV1(
+    urlParams: GetEntitiesDefinitionsV1QueryParams,
+  ): Promise<GetEntitiesDefinitionsV1ApiResponse> {
+    const message: GetEntitiesDefinitionsV1RequestMessage = {
+      type: 'api',
+      api: 'plugins',
+      method: 'getEntitiesDefinitionsV1',
       payload: {
         params: urlParams,
       },

--- a/src/apis/types-response-for.ts
+++ b/src/apis/types-response-for.ts
@@ -198,9 +198,11 @@ import type {
   GetEntitiesConfigsV1RequestMessage as Request60,
   PostEntitiesExecuteDraftV1RequestMessage as Request61,
   PostEntitiesExecuteV1RequestMessage as Request62,
+  GetEntitiesDefinitionsV1RequestMessage as Request63,
   GetEntitiesConfigsV1ResponseMessage as Response60,
   PostEntitiesExecuteDraftV1ResponseMessage as Response61,
   PostEntitiesExecuteV1ResponseMessage as Response62,
+  GetEntitiesDefinitionsV1ResponseMessage as Response63,
 } from './plugins';
 
 import type {
@@ -261,8 +263,10 @@ import type {
 import type {
   GetEntitiesSavedSearchesExecuteV1RequestMessage as Request120,
   PostEntitiesSavedSearchesExecuteV1RequestMessage as Request121,
+  GetEntitiesSavedSearchesV1RequestMessage as Request122,
   GetEntitiesSavedSearchesExecuteV1ResponseMessage as Response120,
   PostEntitiesSavedSearchesExecuteV1ResponseMessage as Response121,
+  GetEntitiesSavedSearchesV1ResponseMessage as Response122,
 } from './loggingapi';
 
 export type ResponseFor<REQ extends RequestMessage> = REQ extends Request00
@@ -439,48 +443,52 @@ export type ResponseFor<REQ extends RequestMessage> = REQ extends Request00
                                                                                                                                                                             ? Response61
                                                                                                                                                                             : REQ extends Request62
                                                                                                                                                                               ? Response62
-                                                                                                                                                                              : REQ extends Request70
-                                                                                                                                                                                ? Response70
-                                                                                                                                                                                : REQ extends Request71
-                                                                                                                                                                                  ? Response71
-                                                                                                                                                                                  : REQ extends Request72
-                                                                                                                                                                                    ? Response72
-                                                                                                                                                                                    : REQ extends Request73
-                                                                                                                                                                                      ? Response73
-                                                                                                                                                                                      : REQ extends Request74
-                                                                                                                                                                                        ? Response74
-                                                                                                                                                                                        : REQ extends Request75
-                                                                                                                                                                                          ? Response75
-                                                                                                                                                                                          : REQ extends Request80
-                                                                                                                                                                                            ? Response80
-                                                                                                                                                                                            : REQ extends Request81
-                                                                                                                                                                                              ? Response81
-                                                                                                                                                                                              : REQ extends Request90
-                                                                                                                                                                                                ? Response90
-                                                                                                                                                                                                : REQ extends Request91
-                                                                                                                                                                                                  ? Response91
-                                                                                                                                                                                                  : REQ extends Request92
-                                                                                                                                                                                                    ? Response92
-                                                                                                                                                                                                    : REQ extends Request100
-                                                                                                                                                                                                      ? Response100
-                                                                                                                                                                                                      : REQ extends Request101
-                                                                                                                                                                                                        ? Response101
-                                                                                                                                                                                                        : REQ extends Request102
-                                                                                                                                                                                                          ? Response102
-                                                                                                                                                                                                          : REQ extends Request103
-                                                                                                                                                                                                            ? Response103
-                                                                                                                                                                                                            : REQ extends Request104
-                                                                                                                                                                                                              ? Response104
-                                                                                                                                                                                                              : REQ extends Request105
-                                                                                                                                                                                                                ? Response105
-                                                                                                                                                                                                                : REQ extends Request106
-                                                                                                                                                                                                                  ? Response106
-                                                                                                                                                                                                                  : REQ extends Request110
-                                                                                                                                                                                                                    ? Response110
-                                                                                                                                                                                                                    : REQ extends Request111
-                                                                                                                                                                                                                      ? Response111
-                                                                                                                                                                                                                      : REQ extends Request120
-                                                                                                                                                                                                                        ? Response120
-                                                                                                                                                                                                                        : REQ extends Request121
-                                                                                                                                                                                                                          ? Response121
-                                                                                                                                                                                                                          : any;
+                                                                                                                                                                              : REQ extends Request63
+                                                                                                                                                                                ? Response63
+                                                                                                                                                                                : REQ extends Request70
+                                                                                                                                                                                  ? Response70
+                                                                                                                                                                                  : REQ extends Request71
+                                                                                                                                                                                    ? Response71
+                                                                                                                                                                                    : REQ extends Request72
+                                                                                                                                                                                      ? Response72
+                                                                                                                                                                                      : REQ extends Request73
+                                                                                                                                                                                        ? Response73
+                                                                                                                                                                                        : REQ extends Request74
+                                                                                                                                                                                          ? Response74
+                                                                                                                                                                                          : REQ extends Request75
+                                                                                                                                                                                            ? Response75
+                                                                                                                                                                                            : REQ extends Request80
+                                                                                                                                                                                              ? Response80
+                                                                                                                                                                                              : REQ extends Request81
+                                                                                                                                                                                                ? Response81
+                                                                                                                                                                                                : REQ extends Request90
+                                                                                                                                                                                                  ? Response90
+                                                                                                                                                                                                  : REQ extends Request91
+                                                                                                                                                                                                    ? Response91
+                                                                                                                                                                                                    : REQ extends Request92
+                                                                                                                                                                                                      ? Response92
+                                                                                                                                                                                                      : REQ extends Request100
+                                                                                                                                                                                                        ? Response100
+                                                                                                                                                                                                        : REQ extends Request101
+                                                                                                                                                                                                          ? Response101
+                                                                                                                                                                                                          : REQ extends Request102
+                                                                                                                                                                                                            ? Response102
+                                                                                                                                                                                                            : REQ extends Request103
+                                                                                                                                                                                                              ? Response103
+                                                                                                                                                                                                              : REQ extends Request104
+                                                                                                                                                                                                                ? Response104
+                                                                                                                                                                                                                : REQ extends Request105
+                                                                                                                                                                                                                  ? Response105
+                                                                                                                                                                                                                  : REQ extends Request106
+                                                                                                                                                                                                                    ? Response106
+                                                                                                                                                                                                                    : REQ extends Request110
+                                                                                                                                                                                                                      ? Response110
+                                                                                                                                                                                                                      : REQ extends Request111
+                                                                                                                                                                                                                        ? Response111
+                                                                                                                                                                                                                        : REQ extends Request120
+                                                                                                                                                                                                                          ? Response120
+                                                                                                                                                                                                                          : REQ extends Request121
+                                                                                                                                                                                                                            ? Response121
+                                                                                                                                                                                                                            : REQ extends Request122
+                                                                                                                                                                                                                              ? Response122
+                                                                                                                                                                                                                              : any;


### PR DESCRIPTION
This PR adds new methods to the logging and plugins apis.  The methods added are:

- `getEntitiesSavedSearchesV1` - fetches data about a given logscale query given an id
- `getEntitiesDefinitionsV1` - fetches data about. a given API Integration given an id