### PR TITLE
Migrates foundry-js to the new Alerts API

### DIFF
--- a/.changeset/loud-lies-enjoy.md
+++ b/.changeset/loud-lies-enjoy.md
@@ -1,0 +1,10 @@
+---
+'@crowdstrike/foundry-js': minor
+---
+
+Added upgraded alerts api methods
+- deprecated `getQueriesAlertsV1` and added `getQueriesAlertsV2`to be used in its place.
+- deprecated `patchCombinedAlertsV2` and added `patchCombinedAlertsV3`to be used in its place.
+- deprecated `patchEntitiesAlertsV2` and added `patchEntitiesAlertsV3`to be used in its place.
+- deprecated `postAggregatesAlertsV1` and added `postAggregatesAlertsV2`to be used in its place.
+- deprecated `postEntitiesAlertsV1` and added `postEntitiesAlertsV2`to be used in its place.

--- a/src/apis/alerts/index.ts
+++ b/src/apis/alerts/index.ts
@@ -65,6 +65,29 @@ export interface GetQueriesAlertsV1RequestMessage
   method: 'getQueriesAlertsV1';
 }
 
+// types for getQueriesAlertsV2
+
+export interface GetQueriesAlertsV2QueryParams extends BaseUrlParams {
+  filter?: string;
+  limit?: QueryParam;
+  offset?: QueryParam;
+  q?: QueryParam;
+  sort?: QueryParam;
+  msspRouteCid?: QueryParam;
+  includeHidden?: QueryParam;
+}
+
+export type GetQueriesAlertsV2ApiResponse = ApiResponsePayload;
+
+export type GetQueriesAlertsV2ResponseMessage =
+  BaseApiResponseMessage<GetQueriesAlertsV2ApiResponse>;
+
+export interface GetQueriesAlertsV2RequestMessage
+  extends BaseApiRequestMessage<GetQueriesAlertsV2QueryParams> {
+  api: AlertsRequestApi;
+  method: 'getQueriesAlertsV2';
+}
+
 // types for patchCombinedAlertsV2
 
 export type PatchCombinedAlertsV2QueryParams = BaseUrlParams;
@@ -85,6 +108,29 @@ export interface PatchCombinedAlertsV2RequestMessage
   method: 'patchCombinedAlertsV2';
 }
 
+// types for patchCombinedAlertsV3
+
+export interface PatchCombinedAlertsV3QueryParams extends BaseUrlParams {
+  msspRouteCid?: QueryParam;
+  includeHidden?: QueryParam;
+}
+
+export type PatchCombinedAlertsV3ApiResponse = ApiResponsePayload;
+
+export interface PatchCombinedAlertsV3PostData {}
+
+export type PatchCombinedAlertsV3ResponseMessage =
+  BaseApiResponseMessage<PatchCombinedAlertsV3ApiResponse>;
+
+export interface PatchCombinedAlertsV3RequestMessage
+  extends BaseApiRequestMessage<
+    PatchCombinedAlertsV3QueryParams,
+    PatchCombinedAlertsV3PostData
+  > {
+  api: AlertsRequestApi;
+  method: 'patchCombinedAlertsV3';
+}
+
 // types for patchEntitiesAlertsV2
 
 export type PatchEntitiesAlertsV2QueryParams = BaseUrlParams;
@@ -103,6 +149,28 @@ export interface PatchEntitiesAlertsV2RequestMessage
   > {
   api: AlertsRequestApi;
   method: 'patchEntitiesAlertsV2';
+}
+
+// types for patchEntitiesAlertsV3
+
+export interface PatchEntitiesAlertsV3QueryParams extends BaseUrlParams {
+  msspRouteCid?: QueryParam;
+}
+
+export type PatchEntitiesAlertsV3ApiResponse = ApiResponsePayload;
+
+export interface PatchEntitiesAlertsV3PostData {}
+
+export type PatchEntitiesAlertsV3ResponseMessage =
+  BaseApiResponseMessage<PatchEntitiesAlertsV3ApiResponse>;
+
+export interface PatchEntitiesAlertsV3RequestMessage
+  extends BaseApiRequestMessage<
+    PatchEntitiesAlertsV3QueryParams,
+    PatchEntitiesAlertsV3PostData
+  > {
+  api: AlertsRequestApi;
+  method: 'patchEntitiesAlertsV3';
 }
 
 // types for patchEntitiesSuppressedDevicesV1
@@ -165,6 +233,45 @@ export interface PostAggregatesAlertsV1RequestMessage
   method: 'postAggregatesAlertsV1';
 }
 
+// types for postAggregatesAlertsV2
+
+export interface PostAggregatesAlertsV2QueryParams extends BaseUrlParams {
+  dateRanges?: QueryParam;
+  field?: QueryParam;
+  filter?: string;
+  from?: QueryParam;
+  include?: QueryParam;
+  interval?: QueryParam;
+  minDocCount?: QueryParam;
+  missing?: QueryParam;
+  msspRouteCid?: QueryParam;
+  name?: QueryParam;
+  q?: QueryParam;
+  ranges?: QueryParam;
+  size?: QueryParam;
+  sort?: QueryParam;
+  subAggregates?: QueryParam;
+  timeZone?: QueryParam;
+  type?: QueryParam;
+  includeHidden?: QueryParam;
+}
+
+export type PostAggregatesAlertsV2ApiResponse = ApiResponsePayload;
+
+export interface PostAggregatesAlertsV2PostData {}
+
+export type PostAggregatesAlertsV2ResponseMessage =
+  BaseApiResponseMessage<PostAggregatesAlertsV2ApiResponse>;
+
+export interface PostAggregatesAlertsV2RequestMessage
+  extends BaseApiRequestMessage<
+    PostAggregatesAlertsV2QueryParams,
+    PostAggregatesAlertsV2PostData
+  > {
+  api: AlertsRequestApi;
+  method: 'postAggregatesAlertsV2';
+}
+
 // types for postEntitiesAlertsV1
 
 export interface PostEntitiesAlertsV1QueryParams extends BaseUrlParams {
@@ -185,6 +292,28 @@ export interface PostEntitiesAlertsV1RequestMessage
   > {
   api: AlertsRequestApi;
   method: 'postEntitiesAlertsV1';
+}
+
+// types for postEntitiesAlertsV2
+
+export interface PostEntitiesAlertsV2QueryParams extends BaseUrlParams {
+  compositeIds?: QueryParam;
+}
+
+export type PostEntitiesAlertsV2ApiResponse = ApiResponsePayload;
+
+export interface PostEntitiesAlertsV2PostData {}
+
+export type PostEntitiesAlertsV2ResponseMessage =
+  BaseApiResponseMessage<PostEntitiesAlertsV2ApiResponse>;
+
+export interface PostEntitiesAlertsV2RequestMessage
+  extends BaseApiRequestMessage<
+    PostEntitiesAlertsV2QueryParams,
+    PostEntitiesAlertsV2PostData
+  > {
+  api: AlertsRequestApi;
+  method: 'postEntitiesAlertsV2';
 }
 
 // types for postEntitiesSuppressedDevicesV1
@@ -212,21 +341,31 @@ export interface PostEntitiesSuppressedDevicesV1RequestMessage
 export type AlertsApiRequestMessage =
   | DeleteEntitiesSuppressedDevicesV1RequestMessage
   | GetQueriesAlertsV1RequestMessage
+  | GetQueriesAlertsV2RequestMessage
   | PatchCombinedAlertsV2RequestMessage
+  | PatchCombinedAlertsV3RequestMessage
   | PatchEntitiesAlertsV2RequestMessage
+  | PatchEntitiesAlertsV3RequestMessage
   | PatchEntitiesSuppressedDevicesV1RequestMessage
   | PostAggregatesAlertsV1RequestMessage
+  | PostAggregatesAlertsV2RequestMessage
   | PostEntitiesAlertsV1RequestMessage
+  | PostEntitiesAlertsV2RequestMessage
   | PostEntitiesSuppressedDevicesV1RequestMessage;
 
 export type AlertsApiResponseMessage =
   | DeleteEntitiesSuppressedDevicesV1ResponseMessage
   | GetQueriesAlertsV1ResponseMessage
+  | GetQueriesAlertsV2ResponseMessage
   | PatchCombinedAlertsV2ResponseMessage
+  | PatchCombinedAlertsV3ResponseMessage
   | PatchEntitiesAlertsV2ResponseMessage
+  | PatchEntitiesAlertsV3ResponseMessage
   | PatchEntitiesSuppressedDevicesV1ResponseMessage
   | PostAggregatesAlertsV1ResponseMessage
+  | PostAggregatesAlertsV2ResponseMessage
   | PostEntitiesAlertsV1ResponseMessage
+  | PostEntitiesAlertsV2ResponseMessage
   | PostEntitiesSuppressedDevicesV1ResponseMessage;
 
 export class AlertsApiBridge {
@@ -255,9 +394,13 @@ export class AlertsApiBridge {
     return this.bridge.postMessage(message);
   }
 
+  /**
+   * @deprecated This method is deprecated. Use getQueriesAlertsV2 instead.
+   */
   async getQueriesAlertsV1(
     urlParams: GetQueriesAlertsV1QueryParams = {},
   ): Promise<GetQueriesAlertsV1ApiResponse> {
+    console.warn('This method is deprecated. Use getQueriesAlertsV2 instead.');
     const message: GetQueriesAlertsV1RequestMessage = {
       type: 'api',
       api: 'alerts',
@@ -270,10 +413,31 @@ export class AlertsApiBridge {
     return this.bridge.postMessage(message);
   }
 
+  async getQueriesAlertsV2(
+    urlParams: GetQueriesAlertsV2QueryParams = {},
+  ): Promise<GetQueriesAlertsV2ApiResponse> {
+    const message: GetQueriesAlertsV2RequestMessage = {
+      type: 'api',
+      api: 'alerts',
+      method: 'getQueriesAlertsV2',
+      payload: {
+        params: urlParams,
+      },
+    };
+
+    return this.bridge.postMessage(message);
+  }
+
+  /**
+   * @deprecated This method is deprecated. Use patchCombinedAlertsV3 instead.
+   */
   async patchCombinedAlertsV2(
     postBody: PatchCombinedAlertsV2PostData,
     urlParams: PatchCombinedAlertsV2QueryParams = {},
   ): Promise<PatchCombinedAlertsV2ApiResponse> {
+    console.warn(
+      'This method is deprecated. Use patchCombinedAlertsV3 instead.',
+    );
     const message: PatchCombinedAlertsV2RequestMessage = {
       type: 'api',
       api: 'alerts',
@@ -287,14 +451,54 @@ export class AlertsApiBridge {
     return this.bridge.postMessage(message);
   }
 
+  async patchCombinedAlertsV3(
+    postBody: PatchCombinedAlertsV3PostData,
+    urlParams: PatchCombinedAlertsV3QueryParams = {},
+  ): Promise<PatchCombinedAlertsV3ApiResponse> {
+    const message: PatchCombinedAlertsV3RequestMessage = {
+      type: 'api',
+      api: 'alerts',
+      method: 'patchCombinedAlertsV3',
+      payload: {
+        body: postBody,
+        params: urlParams,
+      },
+    };
+
+    return this.bridge.postMessage(message);
+  }
+
+  /**
+   * @deprecated This method is deprecated. Use patchEntitiesAlertsV3 instead.
+   */
   async patchEntitiesAlertsV2(
     postBody: PatchEntitiesAlertsV2PostData,
     urlParams: PatchEntitiesAlertsV2QueryParams = {},
   ): Promise<PatchEntitiesAlertsV2ApiResponse> {
+    console.warn(
+      'This method is deprecated. Use patchEntitiesAlertsV3 instead.',
+    );
     const message: PatchEntitiesAlertsV2RequestMessage = {
       type: 'api',
       api: 'alerts',
       method: 'patchEntitiesAlertsV2',
+      payload: {
+        body: postBody,
+        params: urlParams,
+      },
+    };
+
+    return this.bridge.postMessage(message);
+  }
+
+  async patchEntitiesAlertsV3(
+    postBody: PatchEntitiesAlertsV3PostData,
+    urlParams: PatchEntitiesAlertsV3QueryParams = {},
+  ): Promise<PatchEntitiesAlertsV3ApiResponse> {
+    const message: PatchEntitiesAlertsV3RequestMessage = {
+      type: 'api',
+      api: 'alerts',
+      method: 'patchEntitiesAlertsV3',
       payload: {
         body: postBody,
         params: urlParams,
@@ -321,10 +525,16 @@ export class AlertsApiBridge {
     return this.bridge.postMessage(message);
   }
 
+  /**
+   * @deprecated This method is deprecated. Use postAggregatesAlertsV2 instead.
+   */
   async postAggregatesAlertsV1(
     postBody: PostAggregatesAlertsV1PostData,
     urlParams: PostAggregatesAlertsV1QueryParams = {},
   ): Promise<PostAggregatesAlertsV1ApiResponse> {
+    console.warn(
+      'This method is deprecated. Use postAggregatesAlertsV2 instead.',
+    );
     const message: PostAggregatesAlertsV1RequestMessage = {
       type: 'api',
       api: 'alerts',
@@ -338,14 +548,54 @@ export class AlertsApiBridge {
     return this.bridge.postMessage(message);
   }
 
+  async postAggregatesAlertsV2(
+    postBody: PostAggregatesAlertsV2PostData,
+    urlParams: PostAggregatesAlertsV2QueryParams = {},
+  ): Promise<PostAggregatesAlertsV2ApiResponse> {
+    const message: PostAggregatesAlertsV2RequestMessage = {
+      type: 'api',
+      api: 'alerts',
+      method: 'postAggregatesAlertsV2',
+      payload: {
+        body: postBody,
+        params: urlParams,
+      },
+    };
+
+    return this.bridge.postMessage(message);
+  }
+
+  /**
+   * @deprecated This method is deprecated. Use postEntitiesAlertsV2 instead.
+   */
   async postEntitiesAlertsV1(
     postBody: PostEntitiesAlertsV1PostData,
     urlParams: PostEntitiesAlertsV1QueryParams = {},
   ): Promise<PostEntitiesAlertsV1ApiResponse> {
+    console.warn(
+      'This method is deprecated. Use postEntitiesAlertsV2 instead.',
+    );
     const message: PostEntitiesAlertsV1RequestMessage = {
       type: 'api',
       api: 'alerts',
       method: 'postEntitiesAlertsV1',
+      payload: {
+        body: postBody,
+        params: urlParams,
+      },
+    };
+
+    return this.bridge.postMessage(message);
+  }
+
+  async postEntitiesAlertsV2(
+    postBody: PostEntitiesAlertsV2PostData,
+    urlParams: PostEntitiesAlertsV2QueryParams = {},
+  ): Promise<PostEntitiesAlertsV2ApiResponse> {
+    const message: PostEntitiesAlertsV2RequestMessage = {
+      type: 'api',
+      api: 'alerts',
+      method: 'postEntitiesAlertsV2',
       payload: {
         body: postBody,
         params: urlParams,

--- a/src/apis/types-response-for.ts
+++ b/src/apis/types-response-for.ts
@@ -11,20 +11,30 @@ import type { RequestMessage } from '../types';
 import type {
   DeleteEntitiesSuppressedDevicesV1RequestMessage as Request00,
   GetQueriesAlertsV1RequestMessage as Request01,
-  PatchCombinedAlertsV2RequestMessage as Request02,
-  PatchEntitiesAlertsV2RequestMessage as Request03,
-  PatchEntitiesSuppressedDevicesV1RequestMessage as Request04,
-  PostAggregatesAlertsV1RequestMessage as Request05,
-  PostEntitiesAlertsV1RequestMessage as Request06,
-  PostEntitiesSuppressedDevicesV1RequestMessage as Request07,
+  PostEntitiesAlertsV1RequestMessage as Request010,
+  PostEntitiesAlertsV2RequestMessage as Request011,
+  PostEntitiesSuppressedDevicesV1RequestMessage as Request012,
+  GetQueriesAlertsV2RequestMessage as Request02,
+  PatchCombinedAlertsV2RequestMessage as Request03,
+  PatchCombinedAlertsV3RequestMessage as Request04,
+  PatchEntitiesAlertsV2RequestMessage as Request05,
+  PatchEntitiesAlertsV3RequestMessage as Request06,
+  PatchEntitiesSuppressedDevicesV1RequestMessage as Request07,
+  PostAggregatesAlertsV1RequestMessage as Request08,
+  PostAggregatesAlertsV2RequestMessage as Request09,
   DeleteEntitiesSuppressedDevicesV1ResponseMessage as Response00,
   GetQueriesAlertsV1ResponseMessage as Response01,
-  PatchCombinedAlertsV2ResponseMessage as Response02,
-  PatchEntitiesAlertsV2ResponseMessage as Response03,
-  PatchEntitiesSuppressedDevicesV1ResponseMessage as Response04,
-  PostAggregatesAlertsV1ResponseMessage as Response05,
-  PostEntitiesAlertsV1ResponseMessage as Response06,
-  PostEntitiesSuppressedDevicesV1ResponseMessage as Response07,
+  PostEntitiesAlertsV1ResponseMessage as Response010,
+  PostEntitiesAlertsV2ResponseMessage as Response011,
+  PostEntitiesSuppressedDevicesV1ResponseMessage as Response012,
+  GetQueriesAlertsV2ResponseMessage as Response02,
+  PatchCombinedAlertsV2ResponseMessage as Response03,
+  PatchCombinedAlertsV3ResponseMessage as Response04,
+  PatchEntitiesAlertsV2ResponseMessage as Response05,
+  PatchEntitiesAlertsV3ResponseMessage as Response06,
+  PatchEntitiesSuppressedDevicesV1ResponseMessage as Response07,
+  PostAggregatesAlertsV1ResponseMessage as Response08,
+  PostAggregatesAlertsV2ResponseMessage as Response09,
 } from './alerts';
 
 import type {
@@ -285,210 +295,220 @@ export type ResponseFor<REQ extends RequestMessage> = REQ extends Request00
               ? Response06
               : REQ extends Request07
                 ? Response07
-                : REQ extends Request10
-                  ? Response10
-                  : REQ extends Request11
-                    ? Response11
-                    : REQ extends Request12
-                      ? Response12
-                      : REQ extends Request13
-                        ? Response13
-                        : REQ extends Request14
-                          ? Response14
-                          : REQ extends Request15
-                            ? Response15
-                            : REQ extends Request16
-                              ? Response16
-                              : REQ extends Request20
-                                ? Response20
-                                : REQ extends Request21
-                                  ? Response21
-                                  : REQ extends Request22
-                                    ? Response22
-                                    : REQ extends Request23
-                                      ? Response23
-                                      : REQ extends Request24
-                                        ? Response24
-                                        : REQ extends Request25
-                                          ? Response25
-                                          : REQ extends Request26
-                                            ? Response26
-                                            : REQ extends Request27
-                                              ? Response27
-                                              : REQ extends Request28
-                                                ? Response28
-                                                : REQ extends Request29
-                                                  ? Response29
-                                                  : REQ extends Request210
-                                                    ? Response210
-                                                    : REQ extends Request211
-                                                      ? Response211
-                                                      : REQ extends Request212
-                                                        ? Response212
-                                                        : REQ extends Request213
-                                                          ? Response213
-                                                          : REQ extends Request214
-                                                            ? Response214
-                                                            : REQ extends Request215
-                                                              ? Response215
-                                                              : REQ extends Request216
-                                                                ? Response216
-                                                                : REQ extends Request217
-                                                                  ? Response217
-                                                                  : REQ extends Request218
-                                                                    ? Response218
-                                                                    : REQ extends Request219
-                                                                      ? Response219
-                                                                      : REQ extends Request220
-                                                                        ? Response220
-                                                                        : REQ extends Request221
-                                                                          ? Response221
-                                                                          : REQ extends Request222
-                                                                            ? Response222
-                                                                            : REQ extends Request223
-                                                                              ? Response223
-                                                                              : REQ extends Request224
-                                                                                ? Response224
-                                                                                : REQ extends Request225
-                                                                                  ? Response225
-                                                                                  : REQ extends Request30
-                                                                                    ? Response30
-                                                                                    : REQ extends Request31
-                                                                                      ? Response31
-                                                                                      : REQ extends Request32
-                                                                                        ? Response32
-                                                                                        : REQ extends Request33
-                                                                                          ? Response33
-                                                                                          : REQ extends Request34
-                                                                                            ? Response34
-                                                                                            : REQ extends Request35
-                                                                                              ? Response35
-                                                                                              : REQ extends Request36
-                                                                                                ? Response36
-                                                                                                : REQ extends Request37
-                                                                                                  ? Response37
-                                                                                                  : REQ extends Request38
-                                                                                                    ? Response38
-                                                                                                    : REQ extends Request39
-                                                                                                      ? Response39
-                                                                                                      : REQ extends Request310
-                                                                                                        ? Response310
-                                                                                                        : REQ extends Request311
-                                                                                                          ? Response311
-                                                                                                          : REQ extends Request312
-                                                                                                            ? Response312
-                                                                                                            : REQ extends Request313
-                                                                                                              ? Response313
-                                                                                                              : REQ extends Request314
-                                                                                                                ? Response314
-                                                                                                                : REQ extends Request315
-                                                                                                                  ? Response315
-                                                                                                                  : REQ extends Request316
-                                                                                                                    ? Response316
-                                                                                                                    : REQ extends Request317
-                                                                                                                      ? Response317
-                                                                                                                      : REQ extends Request318
-                                                                                                                        ? Response318
-                                                                                                                        : REQ extends Request319
-                                                                                                                          ? Response319
-                                                                                                                          : REQ extends Request320
-                                                                                                                            ? Response320
-                                                                                                                            : REQ extends Request321
-                                                                                                                              ? Response321
-                                                                                                                              : REQ extends Request322
-                                                                                                                                ? Response322
-                                                                                                                                : REQ extends Request323
-                                                                                                                                  ? Response323
-                                                                                                                                  : REQ extends Request324
-                                                                                                                                    ? Response324
-                                                                                                                                    : REQ extends Request325
-                                                                                                                                      ? Response325
-                                                                                                                                      : REQ extends Request326
-                                                                                                                                        ? Response326
-                                                                                                                                        : REQ extends Request327
-                                                                                                                                          ? Response327
-                                                                                                                                          : REQ extends Request328
-                                                                                                                                            ? Response328
-                                                                                                                                            : REQ extends Request329
-                                                                                                                                              ? Response329
-                                                                                                                                              : REQ extends Request330
-                                                                                                                                                ? Response330
-                                                                                                                                                : REQ extends Request331
-                                                                                                                                                  ? Response331
-                                                                                                                                                  : REQ extends Request332
-                                                                                                                                                    ? Response332
-                                                                                                                                                    : REQ extends Request333
-                                                                                                                                                      ? Response333
-                                                                                                                                                      : REQ extends Request40
-                                                                                                                                                        ? Response40
-                                                                                                                                                        : REQ extends Request41
-                                                                                                                                                          ? Response41
-                                                                                                                                                          : REQ extends Request42
-                                                                                                                                                            ? Response42
-                                                                                                                                                            : REQ extends Request43
-                                                                                                                                                              ? Response43
-                                                                                                                                                              : REQ extends Request44
-                                                                                                                                                                ? Response44
-                                                                                                                                                                : REQ extends Request45
-                                                                                                                                                                  ? Response45
-                                                                                                                                                                  : REQ extends Request46
-                                                                                                                                                                    ? Response46
-                                                                                                                                                                    : REQ extends Request47
-                                                                                                                                                                      ? Response47
-                                                                                                                                                                      : REQ extends Request50
-                                                                                                                                                                        ? Response50
-                                                                                                                                                                        : REQ extends Request60
-                                                                                                                                                                          ? Response60
-                                                                                                                                                                          : REQ extends Request61
-                                                                                                                                                                            ? Response61
-                                                                                                                                                                            : REQ extends Request62
-                                                                                                                                                                              ? Response62
-                                                                                                                                                                              : REQ extends Request63
-                                                                                                                                                                                ? Response63
-                                                                                                                                                                                : REQ extends Request70
-                                                                                                                                                                                  ? Response70
-                                                                                                                                                                                  : REQ extends Request71
-                                                                                                                                                                                    ? Response71
-                                                                                                                                                                                    : REQ extends Request72
-                                                                                                                                                                                      ? Response72
-                                                                                                                                                                                      : REQ extends Request73
-                                                                                                                                                                                        ? Response73
-                                                                                                                                                                                        : REQ extends Request74
-                                                                                                                                                                                          ? Response74
-                                                                                                                                                                                          : REQ extends Request75
-                                                                                                                                                                                            ? Response75
-                                                                                                                                                                                            : REQ extends Request80
-                                                                                                                                                                                              ? Response80
-                                                                                                                                                                                              : REQ extends Request81
-                                                                                                                                                                                                ? Response81
-                                                                                                                                                                                                : REQ extends Request90
-                                                                                                                                                                                                  ? Response90
-                                                                                                                                                                                                  : REQ extends Request91
-                                                                                                                                                                                                    ? Response91
-                                                                                                                                                                                                    : REQ extends Request92
-                                                                                                                                                                                                      ? Response92
-                                                                                                                                                                                                      : REQ extends Request100
-                                                                                                                                                                                                        ? Response100
-                                                                                                                                                                                                        : REQ extends Request101
-                                                                                                                                                                                                          ? Response101
-                                                                                                                                                                                                          : REQ extends Request102
-                                                                                                                                                                                                            ? Response102
-                                                                                                                                                                                                            : REQ extends Request103
-                                                                                                                                                                                                              ? Response103
-                                                                                                                                                                                                              : REQ extends Request104
-                                                                                                                                                                                                                ? Response104
-                                                                                                                                                                                                                : REQ extends Request105
-                                                                                                                                                                                                                  ? Response105
-                                                                                                                                                                                                                  : REQ extends Request106
-                                                                                                                                                                                                                    ? Response106
-                                                                                                                                                                                                                    : REQ extends Request110
-                                                                                                                                                                                                                      ? Response110
-                                                                                                                                                                                                                      : REQ extends Request111
-                                                                                                                                                                                                                        ? Response111
-                                                                                                                                                                                                                        : REQ extends Request120
-                                                                                                                                                                                                                          ? Response120
-                                                                                                                                                                                                                          : REQ extends Request121
-                                                                                                                                                                                                                            ? Response121
-                                                                                                                                                                                                                            : REQ extends Request122
-                                                                                                                                                                                                                              ? Response122
-                                                                                                                                                                                                                              : any;
+                : REQ extends Request08
+                  ? Response08
+                  : REQ extends Request09
+                    ? Response09
+                    : REQ extends Request010
+                      ? Response010
+                      : REQ extends Request011
+                        ? Response011
+                        : REQ extends Request012
+                          ? Response012
+                          : REQ extends Request10
+                            ? Response10
+                            : REQ extends Request11
+                              ? Response11
+                              : REQ extends Request12
+                                ? Response12
+                                : REQ extends Request13
+                                  ? Response13
+                                  : REQ extends Request14
+                                    ? Response14
+                                    : REQ extends Request15
+                                      ? Response15
+                                      : REQ extends Request16
+                                        ? Response16
+                                        : REQ extends Request20
+                                          ? Response20
+                                          : REQ extends Request21
+                                            ? Response21
+                                            : REQ extends Request22
+                                              ? Response22
+                                              : REQ extends Request23
+                                                ? Response23
+                                                : REQ extends Request24
+                                                  ? Response24
+                                                  : REQ extends Request25
+                                                    ? Response25
+                                                    : REQ extends Request26
+                                                      ? Response26
+                                                      : REQ extends Request27
+                                                        ? Response27
+                                                        : REQ extends Request28
+                                                          ? Response28
+                                                          : REQ extends Request29
+                                                            ? Response29
+                                                            : REQ extends Request210
+                                                              ? Response210
+                                                              : REQ extends Request211
+                                                                ? Response211
+                                                                : REQ extends Request212
+                                                                  ? Response212
+                                                                  : REQ extends Request213
+                                                                    ? Response213
+                                                                    : REQ extends Request214
+                                                                      ? Response214
+                                                                      : REQ extends Request215
+                                                                        ? Response215
+                                                                        : REQ extends Request216
+                                                                          ? Response216
+                                                                          : REQ extends Request217
+                                                                            ? Response217
+                                                                            : REQ extends Request218
+                                                                              ? Response218
+                                                                              : REQ extends Request219
+                                                                                ? Response219
+                                                                                : REQ extends Request220
+                                                                                  ? Response220
+                                                                                  : REQ extends Request221
+                                                                                    ? Response221
+                                                                                    : REQ extends Request222
+                                                                                      ? Response222
+                                                                                      : REQ extends Request223
+                                                                                        ? Response223
+                                                                                        : REQ extends Request224
+                                                                                          ? Response224
+                                                                                          : REQ extends Request225
+                                                                                            ? Response225
+                                                                                            : REQ extends Request30
+                                                                                              ? Response30
+                                                                                              : REQ extends Request31
+                                                                                                ? Response31
+                                                                                                : REQ extends Request32
+                                                                                                  ? Response32
+                                                                                                  : REQ extends Request33
+                                                                                                    ? Response33
+                                                                                                    : REQ extends Request34
+                                                                                                      ? Response34
+                                                                                                      : REQ extends Request35
+                                                                                                        ? Response35
+                                                                                                        : REQ extends Request36
+                                                                                                          ? Response36
+                                                                                                          : REQ extends Request37
+                                                                                                            ? Response37
+                                                                                                            : REQ extends Request38
+                                                                                                              ? Response38
+                                                                                                              : REQ extends Request39
+                                                                                                                ? Response39
+                                                                                                                : REQ extends Request310
+                                                                                                                  ? Response310
+                                                                                                                  : REQ extends Request311
+                                                                                                                    ? Response311
+                                                                                                                    : REQ extends Request312
+                                                                                                                      ? Response312
+                                                                                                                      : REQ extends Request313
+                                                                                                                        ? Response313
+                                                                                                                        : REQ extends Request314
+                                                                                                                          ? Response314
+                                                                                                                          : REQ extends Request315
+                                                                                                                            ? Response315
+                                                                                                                            : REQ extends Request316
+                                                                                                                              ? Response316
+                                                                                                                              : REQ extends Request317
+                                                                                                                                ? Response317
+                                                                                                                                : REQ extends Request318
+                                                                                                                                  ? Response318
+                                                                                                                                  : REQ extends Request319
+                                                                                                                                    ? Response319
+                                                                                                                                    : REQ extends Request320
+                                                                                                                                      ? Response320
+                                                                                                                                      : REQ extends Request321
+                                                                                                                                        ? Response321
+                                                                                                                                        : REQ extends Request322
+                                                                                                                                          ? Response322
+                                                                                                                                          : REQ extends Request323
+                                                                                                                                            ? Response323
+                                                                                                                                            : REQ extends Request324
+                                                                                                                                              ? Response324
+                                                                                                                                              : REQ extends Request325
+                                                                                                                                                ? Response325
+                                                                                                                                                : REQ extends Request326
+                                                                                                                                                  ? Response326
+                                                                                                                                                  : REQ extends Request327
+                                                                                                                                                    ? Response327
+                                                                                                                                                    : REQ extends Request328
+                                                                                                                                                      ? Response328
+                                                                                                                                                      : REQ extends Request329
+                                                                                                                                                        ? Response329
+                                                                                                                                                        : REQ extends Request330
+                                                                                                                                                          ? Response330
+                                                                                                                                                          : REQ extends Request331
+                                                                                                                                                            ? Response331
+                                                                                                                                                            : REQ extends Request332
+                                                                                                                                                              ? Response332
+                                                                                                                                                              : REQ extends Request333
+                                                                                                                                                                ? Response333
+                                                                                                                                                                : REQ extends Request40
+                                                                                                                                                                  ? Response40
+                                                                                                                                                                  : REQ extends Request41
+                                                                                                                                                                    ? Response41
+                                                                                                                                                                    : REQ extends Request42
+                                                                                                                                                                      ? Response42
+                                                                                                                                                                      : REQ extends Request43
+                                                                                                                                                                        ? Response43
+                                                                                                                                                                        : REQ extends Request44
+                                                                                                                                                                          ? Response44
+                                                                                                                                                                          : REQ extends Request45
+                                                                                                                                                                            ? Response45
+                                                                                                                                                                            : REQ extends Request46
+                                                                                                                                                                              ? Response46
+                                                                                                                                                                              : REQ extends Request47
+                                                                                                                                                                                ? Response47
+                                                                                                                                                                                : REQ extends Request50
+                                                                                                                                                                                  ? Response50
+                                                                                                                                                                                  : REQ extends Request60
+                                                                                                                                                                                    ? Response60
+                                                                                                                                                                                    : REQ extends Request61
+                                                                                                                                                                                      ? Response61
+                                                                                                                                                                                      : REQ extends Request62
+                                                                                                                                                                                        ? Response62
+                                                                                                                                                                                        : REQ extends Request63
+                                                                                                                                                                                          ? Response63
+                                                                                                                                                                                          : REQ extends Request70
+                                                                                                                                                                                            ? Response70
+                                                                                                                                                                                            : REQ extends Request71
+                                                                                                                                                                                              ? Response71
+                                                                                                                                                                                              : REQ extends Request72
+                                                                                                                                                                                                ? Response72
+                                                                                                                                                                                                : REQ extends Request73
+                                                                                                                                                                                                  ? Response73
+                                                                                                                                                                                                  : REQ extends Request74
+                                                                                                                                                                                                    ? Response74
+                                                                                                                                                                                                    : REQ extends Request75
+                                                                                                                                                                                                      ? Response75
+                                                                                                                                                                                                      : REQ extends Request80
+                                                                                                                                                                                                        ? Response80
+                                                                                                                                                                                                        : REQ extends Request81
+                                                                                                                                                                                                          ? Response81
+                                                                                                                                                                                                          : REQ extends Request90
+                                                                                                                                                                                                            ? Response90
+                                                                                                                                                                                                            : REQ extends Request91
+                                                                                                                                                                                                              ? Response91
+                                                                                                                                                                                                              : REQ extends Request92
+                                                                                                                                                                                                                ? Response92
+                                                                                                                                                                                                                : REQ extends Request100
+                                                                                                                                                                                                                  ? Response100
+                                                                                                                                                                                                                  : REQ extends Request101
+                                                                                                                                                                                                                    ? Response101
+                                                                                                                                                                                                                    : REQ extends Request102
+                                                                                                                                                                                                                      ? Response102
+                                                                                                                                                                                                                      : REQ extends Request103
+                                                                                                                                                                                                                        ? Response103
+                                                                                                                                                                                                                        : REQ extends Request104
+                                                                                                                                                                                                                          ? Response104
+                                                                                                                                                                                                                          : REQ extends Request105
+                                                                                                                                                                                                                            ? Response105
+                                                                                                                                                                                                                            : REQ extends Request106
+                                                                                                                                                                                                                              ? Response106
+                                                                                                                                                                                                                              : REQ extends Request110
+                                                                                                                                                                                                                                ? Response110
+                                                                                                                                                                                                                                : REQ extends Request111
+                                                                                                                                                                                                                                  ? Response111
+                                                                                                                                                                                                                                  : REQ extends Request120
+                                                                                                                                                                                                                                    ? Response120
+                                                                                                                                                                                                                                    : REQ extends Request121
+                                                                                                                                                                                                                                      ? Response121
+                                                                                                                                                                                                                                      : REQ extends Request122
+                                                                                                                                                                                                                                        ? Response122
+                                                                                                                                                                                                                                        : any;


### PR DESCRIPTION
- Added `deprecated` warnings to the following Alerts API methods:
   - getQueriesAlertsV1
   - patchCombinedAlertsV2
   - patchEntitiesAlertsV2
   - postAggregatesAlertsV1
   - postEntitiesAlertsV1

- Added new Alerts API methods:
   - getQueriesAlertsV2
   - patchCombinedAlertsV3
   - patchEntitiesAlertsV3
   - postAggregatesAlertsV2
   - postEntitiesAlertsV2