### PR TITLE
Add list objects method to foundry-js

### DIFF
--- a/.changeset/nasty-snails-grab.md
+++ b/.changeset/nasty-snails-grab.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/foundry-js': patch
+---
+
+Added list method to collections

--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ To call on-demand workflow:
   const record = await collection.read('test-key');
   // record.age === 42
   
-  // search collection, `filter` uses FQL (Falcon Query Language)
-  const searchResult = await collection.search({ filter: `name:'*'` });
+  // search collection, `filter` does NOT use FQL (Falcon Query Language). An exact match for the name has to be used in this example below
+  const searchResult = await collection.search({ filter: `name:'exact-name-value'` });
+
+  // list the object keys in the collection, pagination is supported using; `start`, `end` and `limit`.
+  const listResult = await collection.list({ start, end, limit });
   
   // deletes record
   const deleteResponse = await collection.delete('test-key');

--- a/src/abstraction/collection.ts
+++ b/src/abstraction/collection.ts
@@ -16,6 +16,12 @@ interface CollectionSearchDefinition {
   limit: number;
 }
 
+interface CollectionListDefinition {
+  end: string;
+  limit: number;
+  start: string;
+}
+
 export class Collection<DATA extends LocalData = LocalData> {
   constructor(
     private readonly falcon: FalconApi<DATA>,
@@ -96,6 +102,25 @@ export class Collection<DATA extends LocalData = LocalData> {
         offset,
         sort,
         collection: this.definition.collection,
+      },
+    });
+  }
+
+  /**
+   * lists the object keys in the specified collection
+   *
+   * @param searchDefinition
+   * @returns
+   */
+  public async list(options?: CollectionListDefinition) {
+    return this.falcon.bridge.postMessage<CollectionRequestMessage>({
+      type: 'collection',
+      payload: {
+        type: 'list',
+        collection: this.definition.collection,
+        start: options?.start,
+        end: options?.end,
+        limit: options?.limit,
       },
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,13 @@ export interface CollectionRequestMessage extends BaseMessage {
         collection: string;
       }
     | {
+        type: 'list';
+        end?: string;
+        limit?: number;
+        start?: string;
+        collection: string;
+      }
+    | {
         type: 'read' | 'delete';
         key: string;
         collection: string;


### PR DESCRIPTION
- Corrected `README` so it states FQL does not work for the collection `search` function
- Added the `list` method to collections. This will return all the objects in a collection.