### PR TITLE
chore: resolve responseFor excessive stack depth errors to prep for T…

### DIFF
--- a/src/abstraction/collection.ts
+++ b/src/abstraction/collection.ts
@@ -36,7 +36,7 @@ export class Collection<DATA extends LocalData = LocalData> {
    * @returns
    */
   public async write(key: string, data: Record<string, unknown>) {
-    return this.falcon.bridge.postMessage<CollectionRequestMessage>({
+    return this.falcon.bridge.postMessage({
       type: 'collection',
       payload: {
         type: 'write',

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ import { assertConnection } from './utils';
 import type {
   BroadcastMessage,
   CloudFunctionDefinition,
+  ConnectRequestMessage,
   DataUpdateMessage,
   LocalData,
   Theme,
@@ -93,7 +94,10 @@ export default class FalconApi<DATA extends LocalData = LocalData> {
    * This establishes a connection to send messages between the extension and the Falcon Console. Only when established you will be able to call other APIs.
    */
   public async connect(): Promise<{ origin: string; data?: DATA }> {
-    const response = await this.bridge.postMessage({ type: 'connect' });
+    const response = await this.bridge.postMessage<
+      ConnectRequestMessage,
+      { data: DATA; origin: string }
+    >({ type: 'connect' });
 
     if (response !== undefined) {
       const { data, origin } = response;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -11,7 +11,6 @@ import type {
   MessageEnvelope,
   PayloadOf,
   RequestMessage,
-  ResponseFor,
   ResponseMessage,
   UnidirectionalRequestMessage,
 } from './types';
@@ -85,7 +84,10 @@ export class Bridge<DATA extends LocalData = LocalData> {
     window.parent.postMessage(eventData, this.targetOrigin);
   }
 
-  async postMessage<REQ extends RequestMessage>(message: REQ) {
+  async postMessage<
+    REQ extends RequestMessage = RequestMessage,
+    ResolvedValue = void,
+  >(message: REQ): Promise<ResolvedValue> {
     return new Promise((resolve, reject) => {
       const messageId = uuidv4();
 
@@ -107,7 +109,7 @@ export class Bridge<DATA extends LocalData = LocalData> {
           clearTimeout(timeoutTimer);
         }
 
-        resolve(result);
+        resolve(result as ResolvedValue);
       });
 
       const eventData: MessageEnvelope<REQ> = {
@@ -119,7 +121,7 @@ export class Bridge<DATA extends LocalData = LocalData> {
       };
 
       window.parent.postMessage(eventData, this.targetOrigin);
-    }) satisfies Promise<PayloadOf<ResponseFor<REQ, DATA>>>;
+    });
   }
 
   private handleMessageWrapper = (

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -1,12 +1,13 @@
-import type { Bridge } from '../bridge';
-import type {
-  ExtensionIdentifier,
-  FileUploadType,
-  LocalData,
-  OpenModalOptions,
-  PayloadForFileUploadType,
-  ResponseForFileUploadType,
+import {
+  type ExtensionIdentifier,
+  type FileUploadType,
+  type LocalData,
+  type OpenModalOptions,
+  type OpenModalRequestMessage,
+  type PayloadForFileUploadType,
+  type ResponseForFileUploadType,
 } from '../types';
+import type { Bridge } from '../bridge';
 
 /**
  * Invoke UI features within the main Falcon Console.
@@ -36,7 +37,10 @@ export class UI<DATA extends LocalData = LocalData> {
     title: string,
     options: OpenModalOptions = {},
   ): Promise<PAYLOAD | undefined> {
-    const result = await this.bridge.postMessage({
+    const result = await this.bridge.postMessage<
+      OpenModalRequestMessage,
+      PAYLOAD | Error
+    >({
       type: 'openModal',
       payload: {
         extension,


### PR DESCRIPTION
Remove the use of `responseFor` to avoid excessive stack depth errors introduced in Typescript 5.8.3 [here](https://github.com/CrowdStrike/foundry-js/pull/117/checks)