### PR TITLE
chore: add public registry to npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org
+


### PR DESCRIPTION
Adding the `registry` field to `.npmrc` to prevent leaking internal registry URL.