### PR TITLE
Fix code scanning security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Tests'

--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   push-dist:
     name: Push dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Add explicit permissions to GitHub Actions workflows to follow principle of least privilege and address CodeQL security alerts about missing workflow permissions.

## Changes
- **CI workflow**: `contents: read` 
- **Release workflow**: `contents: read, pull-requests: write`
- **Push-dist workflow**: `contents: write`