### PR TITLE
chore: disable sourcemap generation

### DIFF
--- a/config/rollup.config.ts
+++ b/config/rollup.config.ts
@@ -12,8 +12,7 @@ export default defineConfig({
   },
   input: ['src/index.ts'],
   output: {
-    dir: 'dist',
-    sourcemap: true,
+    dir: 'dist'
   },
   plugins: [
     nodeResolve(),


### PR DESCRIPTION
Disables sourcemaps which were being fetched automatically and resulting in CSP issues for users using versions of foundry-js hosted on `https://assets.foundry.crowdstrike.com`