### PR TITLE
feat: sanitize bridge message IDs to prevent invalid UUID processing

### DIFF
--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -39,6 +39,76 @@ test('it throws when receiving an unexpected message', async () => {
   expect(errorSpy).toHaveBeenCalledTimes(1);
 });
 
+test('it throws when receiving a message with invalid messageId format', async () => {
+  const errorSpy = vi.spyOn(bridge, 'throwError');
+  errorSpy.mockImplementation(() => true);
+
+  const invalidMessages = [
+    {
+      meta: { messageId: 'invalid-uuid', version: 'current' },
+      message: { type: 'api', payload: {} },
+    },
+    {
+      meta: { messageId: 'not-a-uuid-at-all', version: 'current' },
+      message: { type: 'api', payload: {} },
+    },
+    {
+      meta: { messageId: '12345', version: 'current' },
+      message: { type: 'api', payload: {} },
+    },
+    {
+      meta: { messageId: 'abc-def-ghi', version: 'current' },
+      message: { type: 'api', payload: {} },
+    },
+    {
+      meta: { messageId: 'malicious-id', version: 'current' },
+      message: { type: 'api', payload: {} },
+    },
+  ];
+
+  for (const invalidMessage of invalidMessages) {
+    window.postMessage(invalidMessage as MessageEnvelope<unknown>);
+    await nextTick();
+  }
+
+  expect(errorSpy).toHaveBeenCalledWith(
+    'Received message with invalid messageId format',
+  );
+  expect(errorSpy).toHaveBeenCalledTimes(invalidMessages.length);
+});
+
+test('it accepts messages with valid UUID messageIds', async () => {
+  const errorSpy = vi.spyOn(bridge, 'throwError');
+  errorSpy.mockImplementation(() => true);
+
+  const validUuidMessages = [
+    {
+      meta: {
+        messageId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        version: 'current',
+      },
+      message: { type: 'api', payload: {} },
+    },
+    {
+      meta: {
+        messageId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+        version: 'current',
+      },
+      message: { type: 'api', payload: {} },
+    },
+  ];
+
+  for (const validMessage of validUuidMessages) {
+    window.postMessage(validMessage as MessageEnvelope<unknown>);
+    await nextTick();
+  }
+
+  expect(errorSpy).not.toHaveBeenCalledWith(
+    'Received message with invalid messageId format',
+  );
+  expect(errorSpy).toHaveBeenCalledWith('Received unexpected message');
+});
+
 test('it can send a message', () => {
   const spy = vi.spyOn(window.parent, 'postMessage');
 


### PR DESCRIPTION
This prevents potential security issues where malicious message IDs could bypass Map lookups or cause unexpected behavior in the bridge message handling system