### PR TITLE
Update ExtensionIdentifier type

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,18 +68,17 @@
   "engines": {
     "node": ">=22"
   },
-  "pnpm": {
-    "overrides": {
-      "human-id": "4.1.2",
-      "@babel/runtime": "7.28.4",
-      "iconv-lite": "0.7.0",
-      "fastq": "1.19.1",
-      "minimatch@<3.1.3": "3.1.5",
-      "minimatch@>=9.0.0 <9.0.6": "9.0.9",
-      "ajv@<6.14.0": "6.14.0",
-      "picomatch@2": "2.3.2",
-      "brace-expansion@2": "2.0.3",
-      "vite": "7.3.2"
-    }
-  }
+  "overrides": {
+    "human-id": "4.1.2",
+    "@babel/runtime": "7.28.4",
+    "iconv-lite": "0.7.0",
+    "fastq": "1.19.1",
+    "minimatch@<3.1.3": "3.1.5",
+    "minimatch@>=9.0.0 <9.0.6": "9.0.9",
+    "ajv@<6.14.0": "6.14.0",
+    "picomatch@2": "2.3.2",
+    "brace-expansion@2": "2.0.3",
+    "vite": "7.3.2"
+  },
+  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,18 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  human-id: 4.1.2
-  '@babel/runtime': 7.28.4
-  iconv-lite: 0.7.0
-  fastq: 1.19.1
-  minimatch@<3.1.3: 3.1.5
-  minimatch@>=9.0.0 <9.0.6: 9.0.9
-  ajv@<6.14.0: 6.14.0
-  picomatch@2: 2.3.2
-  brace-expansion@2: 2.0.3
-  vite: 7.3.2
-
 pnpmfileChecksum: sha256-/xUei6gj/dKxUfIqtP5zzkEgxRHIS1JNnZnETh2KzRA=
 
 importers:
@@ -669,7 +657,7 @@ packages:
     resolution: {integrity: sha512-eNCwzrI5djoauklwP1fuslHBjrbR8rqIVbvNlAnkq1OTa6XT+lX68mrtPirNM9TnR69XUPt4puBCx2Wexseylg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.2
+      vite: ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,7 +428,6 @@ export type PayloadOf<RESPONSE extends ResponseMessage> = RESPONSE['payload'];
 
 export type ExtensionType = 'extension' | 'page';
 
-export interface ExtensionIdentifier {
-  type: ExtensionType;
-  id: string;
-}
+export type ExtensionIdentifier =
+  | { type: ExtensionType; id: string; name?: never }
+  | { type: ExtensionType; name: string; id?: never };


### PR DESCRIPTION
This introduces `ExtensionIdentifier` type  change for supporting not only `id` but also `name`. This is required because we want to support querying `/ui-extensions/entities/page-by-name/v1?name=<name>`.  This allows us to make the necessary changes in our consumer.