### PR TITLE
Upgrade uuid 13.0.0→13.0.1, add postcss and picomatch overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "emittery": "1.2.0",
     "typescript-memoize": "1.1.1",
-    "uuid": "13.0.0"
+    "uuid": "13.0.1"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.5.1",
@@ -77,6 +77,8 @@
     "minimatch@>=9.0.0 <9.0.6": "9.0.9",
     "ajv@<6.14.0": "6.14.0",
     "picomatch@2": "2.3.2",
+    "picomatch@>=4 <4.0.4": "4.0.4",
+    "postcss": "8.5.14",
     "brace-expansion@2": "2.0.3",
     "vite": "7.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       uuid:
-        specifier: 13.0.0
-        version: 13.0.0
+        specifier: 13.0.1
+        version: 13.0.1
     devDependencies:
       '@changesets/changelog-github':
         specifier: 0.5.1
@@ -1419,8 +1419,8 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@13.0.1:
+    resolution: {integrity: sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==}
     hasBin: true
 
   vite@7.3.2:
@@ -2855,7 +2855,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  uuid@13.0.0: {}
+  uuid@13.0.1: {}
 
   vite@7.3.2(@types/node@25.0.3):
     dependencies:


### PR DESCRIPTION
Fixes CVE-2026-41907 (uuid), CVE-2026-41305 (postcss), and CVE-2026-33672 (picomatch).

All tests and linting pass.