### PR TITLE
Improve consumer typing

### DIFF
--- a/src/abstraction/api-integration.ts
+++ b/src/abstraction/api-integration.ts
@@ -1,5 +1,5 @@
 import type FalconApi from '../api';
-import type { LocalData } from '../types';
+import type { ApiResponsePayload, LocalData } from '../types';
 
 interface ApiIntegrationDefinition {
   definitionId: string;
@@ -23,7 +23,7 @@ export class ApiIntegration<DATA extends LocalData = LocalData> {
     private readonly definition: ApiIntegrationDefinition,
   ) {}
 
-  public async execute({ request }: ExecuteParameters = {}) {
+  public async execute<T = unknown>({ request }: ExecuteParameters = {}): Promise<ApiResponsePayload<T>> {
     return this.falcon.api.plugins.postEntitiesExecuteV1({
       resources: [
         {
@@ -32,6 +32,6 @@ export class ApiIntegration<DATA extends LocalData = LocalData> {
           request,
         },
       ],
-    });
+    }) as Promise<ApiResponsePayload<T>>;
   }
 }

--- a/src/abstraction/cloud-function.ts
+++ b/src/abstraction/cloud-function.ts
@@ -56,7 +56,7 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
     private readonly definition: CloudFunctionDefinition,
   ) {}
 
-  private async execute({ path, method, body, params }: ExecuteParameters) {
+  private async execute<T = unknown>({ path, method, body, params }: ExecuteParameters): Promise<T> {
     const functionDefinition =
       'id' in this.definition
         ? {
@@ -78,13 +78,13 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
       },
     });
 
-    return new Promise((resolve, reject) => {
+    return new Promise<T>((resolve, reject) => {
       const execution = result?.resources?.[0] as { execution_id?: string };
 
       if (!execution?.execution_id) {
         reject(result?.errors);
       } else {
-        this.pollForResult({
+        this.pollForResult<T>({
           resolve,
           reject,
           executionId: execution?.execution_id,
@@ -93,25 +93,25 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
     });
   }
 
-  private async getExecutionResult(
+  private async getExecutionResult<T = unknown>(
     executionId: string,
-  ): Promise<Record<string, unknown> | undefined> {
+  ): Promise<T | undefined> {
     const resultResponse =
       await this.falcon.api.faasGateway.getEntitiesExecutionV1({
         id: executionId,
       });
 
-    const executionResult = resultResponse?.resources?.[0] as { payload?: unknown };
+    const executionResult = resultResponse?.resources?.[0] as { payload?: T };
 
-    return executionResult?.payload as Record<string, unknown> | undefined;
+    return executionResult?.payload;
   }
 
-  private pollForResult({
+  private pollForResult<T = unknown>({
     resolve,
     reject,
     executionId,
   }: {
-    resolve: (value: unknown) => void;
+    resolve: (value: T) => void;
     reject: (value?: unknown) => void;
     executionId: string;
   }) {
@@ -119,7 +119,7 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
 
     this.intervalId = window.setInterval(async () => {
       try {
-        const payload = await this.getExecutionResult(executionId);
+        const payload = await this.getExecutionResult<T>(executionId);
 
         if (payload) {
           window.clearInterval(this.intervalId);
@@ -152,8 +152,8 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
       path,
       queryParams: searchParams,
 
-      get: async (params: GetParameters['params'] = {}) => {
-        return this.get({
+      get: async <T = unknown>(params: GetParameters['params'] = {}) => {
+        return this.get<T>({
           path,
           params: {
             query: params?.query ?? searchParams ?? {},
@@ -162,11 +162,11 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
         });
       },
 
-      post: async (
+      post: async <T = unknown>(
         body: PostParameters['body'],
         params: PostParameters['params'] = {},
       ) => {
-        return this.post({
+        return this.post<T>({
           path,
           params: {
             query: params?.query ?? searchParams ?? {},
@@ -176,11 +176,11 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
         });
       },
 
-      patch: async (
+      patch: async <T = unknown>(
         body: PatchParameters['body'],
         params: PostParameters['params'] = {},
       ) => {
-        return this.patch({
+        return this.patch<T>({
           path,
           params: {
             query: params?.query ?? searchParams ?? {},
@@ -190,11 +190,11 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
         });
       },
 
-      put: async (
+      put: async <T = unknown>(
         body: PutParameters['body'],
         params: PostParameters['params'] = {},
       ) => {
-        return this.put({
+        return this.put<T>({
           path,
           params: {
             query: params?.query ?? searchParams ?? {},
@@ -204,11 +204,11 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
         });
       },
 
-      delete: async (
+      delete: async <T = unknown>(
         body: DeleteParameters['body'],
         params: PostParameters['params'] = {},
       ) => {
-        return this.delete({
+        return this.delete<T>({
           path,
           params: {
             query: params?.query ?? searchParams ?? {},
@@ -220,16 +220,16 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
     };
   }
 
-  public async get({ path, params }: GetParameters) {
-    return this.execute({
+  public async get<T = unknown>({ path, params }: GetParameters): Promise<T> {
+    return this.execute<T>({
       path,
       method: CloudFunction.GET,
       params,
     });
   }
 
-  public async post({ path, params, body }: PostParameters) {
-    return this.execute({
+  public async post<T = unknown>({ path, params, body }: PostParameters): Promise<T> {
+    return this.execute<T>({
       path,
       method: CloudFunction.POST,
       body,
@@ -237,8 +237,8 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
     });
   }
 
-  public async patch({ path, params, body }: PatchParameters) {
-    return this.execute({
+  public async patch<T = unknown>({ path, params, body }: PatchParameters): Promise<T> {
+    return this.execute<T>({
       path,
       method: CloudFunction.PATCH,
       body,
@@ -246,8 +246,8 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
     });
   }
 
-  public async put({ path, params, body }: PutParameters) {
-    return this.execute({
+  public async put<T = unknown>({ path, params, body }: PutParameters): Promise<T> {
+    return this.execute<T>({
       path,
       method: CloudFunction.PUT,
       body,
@@ -255,8 +255,8 @@ export class CloudFunction<DATA extends LocalData = LocalData> {
     });
   }
 
-  public async delete({ path, params, body }: DeleteParameters) {
-    return this.execute({
+  public async delete<T = unknown>({ path, params, body }: DeleteParameters): Promise<T> {
+    return this.execute<T>({
       path,
       method: CloudFunction.DELETE,
       body,

--- a/src/abstraction/collection.ts
+++ b/src/abstraction/collection.ts
@@ -1,6 +1,8 @@
 import type FalconApi from '../api';
 import type { CollectionRequestMessage, LocalData } from '../types';
 
+export type CollectionItem = object;
+
 interface CollectionDefinition {
   collection: string;
 }
@@ -22,7 +24,10 @@ interface CollectionListDefinition {
   start: string;
 }
 
-export class Collection<DATA extends LocalData = LocalData> {
+export class Collection<
+  DATA extends LocalData = LocalData,
+  ITEM extends CollectionItem = CollectionItem,
+> {
   constructor(
     private readonly falcon: FalconApi<DATA>,
     private readonly definition: CollectionDefinition,
@@ -35,8 +40,8 @@ export class Collection<DATA extends LocalData = LocalData> {
    * @param data
    * @returns
    */
-  public async write(key: string, data: Record<string, unknown>) {
-    return this.falcon.bridge.postMessage({
+  public async write<T extends ITEM = ITEM>(key: string, data: T) {
+    return this.falcon.bridge.postMessage<CollectionRequestMessage, T>({
       type: 'collection',
       payload: {
         type: 'write',
@@ -53,8 +58,8 @@ export class Collection<DATA extends LocalData = LocalData> {
    * @param key
    * @returns
    */
-  public async read(key: string) {
-    return this.falcon.bridge.postMessage<CollectionRequestMessage>({
+  public async read<T extends ITEM = ITEM>(key: string) {
+    return this.falcon.bridge.postMessage<CollectionRequestMessage, T>({
       type: 'collection',
       payload: {
         type: 'read',
@@ -87,13 +92,13 @@ export class Collection<DATA extends LocalData = LocalData> {
    * @param searchDefinition
    * @returns
    */
-  public async search({
+  public async search<T extends ITEM = ITEM>({
     filter,
     offset,
     sort,
     limit,
   }: CollectionSearchDefinition) {
-    return this.falcon.bridge.postMessage<CollectionRequestMessage>({
+    return this.falcon.bridge.postMessage<CollectionRequestMessage, T[]>({
       type: 'collection',
       payload: {
         type: 'search',

--- a/src/abstraction/logscale.ts
+++ b/src/abstraction/logscale.ts
@@ -40,11 +40,11 @@ export class Logscale<DATA extends LocalData = LocalData> {
    * @param query
    * @returns Promise that resolves with the data
    */
-  public async query(
+  public async query<T = unknown>(
     // @todo the proper type here is unclear  - we need to make clear how the user needs to call this
     query: LogscaleRequestMessage['payload']['data'],
   ) {
-    return this.falcon.bridge.postMessage<LogscaleRequestMessage>({
+    return this.falcon.bridge.postMessage<LogscaleRequestMessage, T>({
       type: 'loggingapi',
       payload: {
         type: 'dynamic-execute',
@@ -59,11 +59,11 @@ export class Logscale<DATA extends LocalData = LocalData> {
    * @param savedQuery
    * @returns
    */
-  public async savedQuery(
+  public async savedQuery<T = unknown>(
     // @todo the proper type here is unclear  - we need to make clear how the user needs to call this
     savedQuery: LogscaleRequestMessage['payload']['data'],
   ) {
-    return this.falcon.bridge.postMessage<LogscaleRequestMessage>({
+    return this.falcon.bridge.postMessage<LogscaleRequestMessage, T>({
       type: 'loggingapi',
       payload: {
         type: 'saved-query-execute',

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import FalconPublicApis from './apis/public-api';
 import { ApiIntegration } from './abstraction/api-integration';
 import { Bridge } from './bridge';
 import { CloudFunction } from './abstraction/cloud-function';
-import { Collection } from './abstraction/collection';
+import { Collection, type CollectionItem } from './abstraction/collection';
 import { Logscale } from './abstraction/logscale';
 import { Memoize } from 'typescript-memoize';
 import { Navigation } from './lib/navigation';
@@ -212,10 +212,14 @@ export default class FalconApi<DATA extends LocalData = LocalData> {
    * @param definition
    * @returns
    */
-  collection({ collection }: { collection: string }) {
+  collection<ITEM extends CollectionItem = CollectionItem>({
+    collection,
+  }: {
+    collection: string;
+  }) {
     assertConnection(this);
 
-    const co = new Collection(this, { collection });
+    const co = new Collection<DATA, ITEM>(this, { collection });
 
     this.collections.push(co);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { Bridge } from './bridge';
 export { default } from './api';
+export { type CollectionItem } from './abstraction/collection';
 export * from './apis/types';
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,7 +197,7 @@ export interface CollectionRequestMessage extends BaseMessage {
         type: 'write';
         key: string;
         collection: string;
-        data: Record<string, unknown>;
+        data: object;
       }
     | {
         type: 'search';

--- a/tests/abstraction/type-generics.test-d.ts
+++ b/tests/abstraction/type-generics.test-d.ts
@@ -1,0 +1,165 @@
+import { assertType, describe, test } from 'vitest';
+import FalconApi from '../../src/';
+import type { ApiResponsePayload } from '../../src/types';
+
+interface User {
+  name: string;
+  email: string;
+}
+
+interface Alert {
+  id: number;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  tags: string[];
+  metadata?: Record<string, string>;
+}
+
+interface NestedConfig {
+  enabled: boolean;
+  rules: {
+    name: string;
+    conditions: { field: string; operator: string; value: unknown }[];
+  }[];
+}
+
+declare const api: FalconApi;
+
+describe('Collection generics', () => {
+  test('class-level generic types read()', () => {
+    const collection = api.collection<User>({ collection: 'users' });
+
+    assertType<Promise<User>>(collection.read('key'));
+  });
+
+  test('class-level generic types write()', () => {
+    const collection = api.collection<User>({ collection: 'users' });
+
+    assertType<Promise<User>>(
+      collection.write('key', { name: 'Dan', email: 'dan@test.com' }),
+    );
+  });
+
+  test('class-level generic types search()', () => {
+    const collection = api.collection<User>({ collection: 'users' });
+
+    assertType<Promise<User[]>>(
+      collection.search({ filter: '', offset: '', sort: '', limit: 10 }),
+    );
+  });
+
+  test('method-level generic overrides class-level', () => {
+    const collection = api.collection({ collection: 'users' });
+
+    assertType<Promise<User>>(collection.read<User>('key'));
+  });
+
+  test('works with union and optional fields', () => {
+    const collection = api.collection<Alert>({ collection: 'alerts' });
+
+    assertType<Promise<Alert>>(collection.read('alert-1'));
+    assertType<Promise<Alert[]>>(
+      collection.search({ filter: '', offset: '', sort: '', limit: 10 }),
+    );
+  });
+
+  test('works with deeply nested types', () => {
+    const collection = api.collection<NestedConfig>({ collection: 'configs' });
+
+    assertType<Promise<NestedConfig>>(collection.read('config-1'));
+  });
+});
+
+describe('CloudFunction generics', () => {
+  test('get() accepts a response type', () => {
+    const fn = api.cloudFunction({ id: 'fn', version: 1 });
+
+    assertType<Promise<User>>(fn.get<User>({ path: '/users/1' }));
+  });
+
+  test('post() accepts a response type', () => {
+    const fn = api.cloudFunction({ id: 'fn', version: 1 });
+
+    assertType<Promise<User>>(fn.post<User>({ path: '/users', body: {} }));
+  });
+
+  test('path().get() accepts a response type', () => {
+    const fn = api.cloudFunction({ id: 'fn', version: 1 });
+    const endpoint = fn.path('/users');
+
+    assertType<Promise<User>>(endpoint.get<User>());
+  });
+
+  test('defaults to unknown without generic', () => {
+    const fn = api.cloudFunction({ id: 'fn', version: 1 });
+
+    assertType<Promise<unknown>>(fn.get({ path: '/users' }));
+  });
+
+  test('works with nested response types', () => {
+    const fn = api.cloudFunction({ id: 'fn', version: 1 });
+
+    assertType<Promise<NestedConfig>>(
+      fn.get<NestedConfig>({ path: '/configs/1' }),
+    );
+  });
+
+  test('different methods can return different types', () => {
+    const fn = api.cloudFunction({ id: 'fn', version: 1 });
+
+    assertType<Promise<User>>(fn.get<User>({ path: '/users/1' }));
+    assertType<Promise<Alert>>(fn.get<Alert>({ path: '/alerts/1' }));
+  });
+});
+
+describe('ApiIntegration generics', () => {
+  test('execute() accepts a response type', () => {
+    const integration = api.apiIntegration({
+      definitionId: 'def',
+      operationId: 'op',
+    });
+
+    assertType<Promise<ApiResponsePayload<User>>>(integration.execute<User>());
+  });
+
+  test('defaults to unknown without generic', () => {
+    const integration = api.apiIntegration({
+      definitionId: 'def',
+      operationId: 'op',
+    });
+
+    assertType<Promise<ApiResponsePayload<unknown>>>(integration.execute());
+  });
+
+  test('works with complex resource types', () => {
+    const integration = api.apiIntegration({
+      definitionId: 'def',
+      operationId: 'op',
+    });
+
+    assertType<Promise<ApiResponsePayload<Alert>>>(
+      integration.execute<Alert>(),
+    );
+  });
+});
+
+describe('Logscale generics', () => {
+  test('query() accepts a response type', () => {
+    assertType<Promise<User[]>>(api.logscale.query<User[]>({ id: 'test' }));
+  });
+
+  test('savedQuery() accepts a response type', () => {
+    assertType<Promise<User[]>>(
+      api.logscale.savedQuery<User[]>({ id: 'test' }),
+    );
+  });
+
+  test('defaults to unknown without generic', () => {
+    assertType<Promise<unknown>>(api.logscale.query({ id: 'test' }));
+  });
+
+  test('works with complex result types', () => {
+    assertType<Promise<Alert[]>>(
+      api.logscale.query<Alert[]>({ id: 'alerts-query' }),
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
+    typecheck: {
+      enabled: true,
+      include: ['**/*.test-d.ts'],
+    },
   },
 });


### PR DESCRIPTION
Adds generic type parameters to all SDK methods that return author-defined data.

**Affected modules:**
- **Collection** — `read`, `write`, `search` now accept a type parameter (can be set per-method or once at the class level via `falcon.collection<MyType>(...)`)
- **CloudFunction** — `get`, `post`, `patch`, `put`, `delete` (including `.path()` variants) now accept a response type parameter
- **ApiIntegration** — `execute` now accepts a response type parameter
- **Logscale** — `query` and `savedQuery` now accept a response type parameter

Previously, all of these methods returned `unknown` or `void`, forcing consumers to manually cast results or lose type safety entirely. Now they can declare their data shapes upfront and get:

- IDE autocomplete on returned objects
- Compile-time detection of typos and incorrect field access
- Type-checked `write` payloads (wrong shape won't compile)
- Downstream type inference without manual casting

```typescript
interface Incident {
  id: string;
  severity: 'low' | 'medium' | 'high';
  assignee: string;
}

const incidents = falcon.collection<Incident>({ collection: 'incidents' });
const incident = await incidents.read('inc-123'); // typed as Incident
incident.severity; // autocomplete, typo detection
```

## Non-breaking

All generics default to `unknown` or `object`, so existing untyped usage compiles and behaves identically.

## Test plan

- Added `type-generics.test-d.ts` — 19 compile-time type assertions covering all modules with varied type shapes (flat interfaces, union types, optional fields, deeply nested objects)
- All 64 tests pass (45 runtime + 19 type-level)
