### PR TITLE
feat: add agentworks invocation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,32 @@ To call API Integration, App should be initially provisioned, and configuration 
 });
 ```
 
+### Working with AgentWorks
+
+To invoke an AgentWorks agent and stream its response, call `falcon.agentWorks.invoke()` with the agent ID and any parameters. It returns an `AgentStream` that emits `data` chunks as they arrive, followed by a terminal `end` or `error`.
+
+```javascript
+  const stream = falcon.agentWorks.invoke('<agent-id>', { prompt: 'Summarize this detection' });
+
+  // receive each chunk as it streams in
+  stream.on('data', (chunk) => {
+    // append chunk to your UI
+  });
+
+  // the stream completed successfully
+  stream.on('end', () => {
+    // finalize output
+  });
+
+  // the stream terminated with an error
+  stream.on('error', (err) => {
+    // handle err.message
+  });
+
+  // cancel an in-flight stream early
+  stream.abort();
+```
+
 ### Navigation utilities
 
 As the Page or UI extension will run inside a sandboxed iframe, the `navigateTo` method must be used to change the url of the parent context (Falcon Console).

--- a/src/abstraction/agent-works.ts
+++ b/src/abstraction/agent-works.ts
@@ -23,7 +23,7 @@ type AgentStreamEventName = keyof AgentStreamEvents;
  * `data` chunks as they arrive, plus a terminal `end` or `error`:
  *
  * ```js
- * const stream = await api.agentWorks.invoke('agent-id', { prompt: '...' });
+ * const stream = api.agentWorks.invoke('agent-id', { prompt: '...' });
  *
  * stream.on('data', (chunk) => render(chunk));
  * stream.on('error', (err) => showError(err));
@@ -38,6 +38,7 @@ export class AgentStream<DATA extends LocalData = LocalData> {
   private bridge: Bridge<DATA>;
   private messageId: string;
   private close: () => void;
+  private onFinish?: () => void;
   private finished = false;
 
   /**
@@ -46,8 +47,10 @@ export class AgentStream<DATA extends LocalData = LocalData> {
   constructor(
     bridge: Bridge<DATA>,
     request: { agentId: string; params?: AgentWorksInvokeParams },
+    onFinish?: () => void,
   ) {
     this.bridge = bridge;
+    this.onFinish = onFinish;
 
     const { messageId, close } = bridge.openStream(
       {
@@ -92,6 +95,7 @@ export class AgentStream<DATA extends LocalData = LocalData> {
 
     this.finished = true;
     this.close();
+    this.onFinish?.();
   }
 
   /**
@@ -163,21 +167,30 @@ export class AgentWorks<DATA extends LocalData = LocalData> {
     agentId: string,
     params?: AgentWorksInvokeParams,
   ): AgentStream<DATA> {
-    const stream = new AgentStream(this.bridge, {
-      agentId,
-      params,
-    });
+    const stream: AgentStream<DATA> = new AgentStream(
+      this.bridge,
+      { agentId, params },
+      () => this.remove(stream),
+    );
 
     this.streams.push(stream);
 
     return stream;
   }
 
+  private remove(stream: AgentStream<DATA>): void {
+    const index = this.streams.indexOf(stream);
+
+    if (index !== -1) {
+      this.streams.splice(index, 1);
+    }
+  }
+
   /**
    * @internal
    */
   public destroy(): void {
-    this.streams.forEach((stream) => stream.destroy());
+    [...this.streams].forEach((stream) => stream.destroy());
     this.streams = [];
   }
 }

--- a/src/abstraction/agent-works.ts
+++ b/src/abstraction/agent-works.ts
@@ -1,0 +1,183 @@
+import Emittery from 'emittery';
+
+import type { Bridge } from '../bridge';
+import type {
+  AgentWorksInvokeParams,
+  AgentWorksResponseMessage,
+  LocalData,
+} from '../types';
+
+interface AgentStreamEvents {
+  /** A raw chunk forwarded from the AgentWorks streaming API. */
+  data: unknown;
+  /** The stream encountered an error and has terminated. */
+  error: Error;
+  /** The stream completed successfully. */
+  end: undefined;
+}
+
+type AgentStreamEventName = keyof AgentStreamEvents;
+
+/**
+ * A single agent invocation stream. Subscribe with {@link on} to receive
+ * `data` chunks as they arrive, plus a terminal `end` or `error`:
+ *
+ * ```js
+ * const stream = await api.agentWorks.invoke('agent-id', { prompt: '...' });
+ *
+ * stream.on('data', (chunk) => render(chunk));
+ * stream.on('error', (err) => showError(err));
+ * stream.on('end', () => finish());
+ *
+ * // cancel early:
+ * stream.abort();
+ * ```
+ */
+export class AgentStream<DATA extends LocalData = LocalData> {
+  private emitter = new Emittery<AgentStreamEvents>();
+  private bridge: Bridge<DATA>;
+  private messageId: string;
+  private close: () => void;
+  private finished = false;
+
+  /**
+   * @internal
+   */
+  constructor(
+    bridge: Bridge<DATA>,
+    request: { agentId: string; params?: AgentWorksInvokeParams },
+  ) {
+    this.bridge = bridge;
+
+    const { messageId, close } = bridge.openStream(
+      {
+        type: 'agentWorks',
+        payload: {
+          action: 'invoke',
+          agentId: request.agentId,
+          params: request.params,
+        },
+      },
+      (payload) => this.handlePayload(payload),
+    );
+
+    this.messageId = messageId;
+    this.close = close;
+  }
+
+  private handlePayload(payload: AgentWorksResponseMessage['payload']): void {
+    if (this.finished) {
+      return;
+    }
+
+    switch (payload.subtype) {
+      case 'chunk':
+        void this.emitter.emit('data', payload.data);
+        break;
+      case 'complete':
+        this.finish();
+        void this.emitter.emit('end');
+        break;
+      case 'error':
+        this.finish();
+        void this.emitter.emit('error', new Error(payload.error));
+        break;
+    }
+  }
+
+  private finish(): void {
+    if (this.finished) {
+      return;
+    }
+
+    this.finished = true;
+    this.close();
+  }
+
+  /**
+   * Subscribe to a stream event. Returns an unsubscribe function.
+   */
+  public on<Name extends AgentStreamEventName>(
+    eventName: Name,
+    listener: (eventData: AgentStreamEvents[Name]) => void,
+  ): () => void {
+    return this.emitter.on(eventName, listener);
+  }
+
+  /**
+   * Unsubscribe a previously registered listener.
+   */
+  public off<Name extends AgentStreamEventName>(
+    eventName: Name,
+    listener: (eventData: AgentStreamEvents[Name]) => void,
+  ): void {
+    this.emitter.off(eventName, listener);
+  }
+
+  /**
+   * Cancel an in-flight stream. Tears down the host-side HTTP stream and emits
+   * a final `end`. Safe to call multiple times.
+   */
+  public abort(): void {
+    if (this.finished) {
+      return;
+    }
+
+    this.bridge.sendStreamMessage(this.messageId, {
+      type: 'agentWorks',
+      payload: { action: 'abort' },
+    });
+
+    this.finish();
+    void this.emitter.emit('end');
+  }
+
+  /**
+   * @internal
+   */
+  public destroy(): void {
+    this.abort();
+    this.emitter.clearListeners();
+  }
+}
+
+/**
+ * Entry point for invoking AgentWorks agents. Accessed via `api.agentWorks`.
+ */
+export class AgentWorks<DATA extends LocalData = LocalData> {
+  private streams: AgentStream<DATA>[] = [];
+
+  /**
+   * @internal
+   */
+  constructor(private readonly bridge: Bridge<DATA>) {}
+
+  /**
+   * Invoke an AgentWorks agent and stream its response.
+   *
+   * @param agentId the ID of the agent to invoke
+   * @param params parameters forwarded as-is to the AgentWorks API
+   * @returns an {@link AgentStream} emitting `data`, `end`, and `error` events
+   */
+  public invoke(
+    agentId: string,
+    params?: AgentWorksInvokeParams,
+  ): AgentStream<DATA> {
+    const stream = new AgentStream(this.bridge, {
+      agentId,
+      params,
+    });
+
+    this.streams.push(stream);
+
+    return stream;
+  }
+
+  /**
+   * @internal
+   */
+  public destroy(): void {
+    this.streams.forEach((stream) => stream.destroy());
+    this.streams = [];
+  }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -253,12 +253,14 @@ export default class FalconApi<DATA extends LocalData = LocalData> {
    * stream their responses.
    *
    * ```js
-   * const stream = await api.agentWorks.invoke('agent-id', { prompt: '...' });
+   * const stream = api.agentWorks.invoke('agent-id', { prompt: '...' });
    *
    * stream.on('data', (chunk) => console.log(chunk));
    * stream.on('end', () => console.log('done'));
    * ```
    */
+  // Cached manually rather than via @Memoize() because destroy() needs the
+  // instance reference to tear down any open streams.
   get agentWorks() {
     assertConnection(this);
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import Emittery from 'emittery';
 import FalconPublicApis from './apis/public-api';
+import { AgentWorks } from './abstraction/agent-works';
 import { ApiIntegration } from './abstraction/api-integration';
 import { Bridge } from './bridge';
 import { CloudFunction } from './abstraction/cloud-function';
@@ -87,6 +88,7 @@ export default class FalconApi<DATA extends LocalData = LocalData> {
   private cloudFunctions: CloudFunction<DATA>[] = [];
   private apiIntegrations: ApiIntegration<DATA>[] = [];
   private collections: Collection<DATA>[] = [];
+  private _agentWorks?: AgentWorks<DATA>;
 
   /**
    * Connect to the main Falcon Console from within your UI extension.
@@ -246,9 +248,31 @@ export default class FalconApi<DATA extends LocalData = LocalData> {
     return new Logscale(this);
   }
 
+  /**
+   * The {@link AgentWorks} class allows you to invoke AgentWorks agents and
+   * stream their responses.
+   *
+   * ```js
+   * const stream = await api.agentWorks.invoke('agent-id', { prompt: '...' });
+   *
+   * stream.on('data', (chunk) => console.log(chunk));
+   * stream.on('end', () => console.log('done'));
+   * ```
+   */
+  get agentWorks() {
+    assertConnection(this);
+
+    if (!this._agentWorks) {
+      this._agentWorks = new AgentWorks(this.bridge);
+    }
+
+    return this._agentWorks;
+  }
+
   destroy() {
     this.cloudFunctions.forEach((cf) => cf.destroy());
 
+    this._agentWorks?.destroy();
     this.resizeTracker?.destroy();
     this.bridge.destroy();
   }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -4,6 +4,8 @@ import { VERSION } from './apis/version';
 import { isValidResponse } from './utils';
 
 import type {
+  AgentWorksRequestMessage,
+  AgentWorksResponseMessage,
   BroadcastMessage,
   DataUpdateMessage,
   LivereloadMessage,
@@ -56,6 +58,11 @@ export class Bridge<DATA extends LocalData = LocalData> {
   private pendingMessages = new Map<
     string,
     (_result: PayloadOf<ResponseMessage>) => void
+  >();
+
+  private streamSubscriptions = new Map<
+    string,
+    (_payload: AgentWorksResponseMessage['payload']) => void
   >();
 
   private targetOrigin = '*';
@@ -133,6 +140,55 @@ export class Bridge<DATA extends LocalData = LocalData> {
     });
   }
 
+  /**
+   * Open a long-lived stream. Unlike {@link postMessage}, the subscription is
+   * not removed after the first response: many messages may be delivered for
+   * the same `messageId` until the caller invokes the returned `close()`.
+   *
+   * No timeout is applied, since a stream can run for an arbitrary duration.
+   */
+  openStream(
+    message: AgentWorksRequestMessage,
+    subscriber: (_payload: AgentWorksResponseMessage['payload']) => void,
+  ): { messageId: string; close: () => void } {
+    const messageId = uuidv4();
+
+    this.streamSubscriptions.set(messageId, subscriber);
+
+    const eventData: MessageEnvelope<AgentWorksRequestMessage> = {
+      message,
+      meta: {
+        messageId,
+        version: VERSION,
+      },
+    };
+
+    window.parent.postMessage(eventData, this.targetOrigin);
+
+    return {
+      messageId,
+      close: () => {
+        this.streamSubscriptions.delete(messageId);
+      },
+    };
+  }
+
+  /**
+   * Send a follow-up message that reuses an existing stream's `messageId`
+   * (e.g. an `abort` request for an in-flight invocation).
+   */
+  sendStreamMessage(messageId: string, message: AgentWorksRequestMessage) {
+    const eventData: MessageEnvelope<AgentWorksRequestMessage> = {
+      message,
+      meta: {
+        messageId,
+        version: VERSION,
+      },
+    };
+
+    window.parent.postMessage(eventData, this.targetOrigin);
+  }
+
   private handleMessageWrapper = (
     event: MessageEvent<MessageEnvelope<ResponseMessage<DATA>> | unknown>,
   ) => {
@@ -175,6 +231,19 @@ export class Bridge<DATA extends LocalData = LocalData> {
     const sanitizedMessageId = sanitizeMessageId(messageId);
     if (!sanitizedMessageId) {
       this.throwError(`Received message with invalid messageId format`);
+      return;
+    }
+
+    if (message.type === 'agentWorks') {
+      // Streaming responses deliver many messages for one messageId. The
+      // subscription is owned by the AgentStream, which removes it via close()
+      // once the stream completes, errors, or is aborted.
+      const subscriber = this.streamSubscriptions.get(sanitizedMessageId);
+
+      if (typeof subscriber === 'function') {
+        subscriber(message.payload);
+      }
+
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { Bridge } from './bridge';
 export { default } from './api';
 export { type CollectionItem } from './abstraction/collection';
+export { AgentWorks, AgentStream } from './abstraction/agent-works';
 export * from './apis/types';
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ export type MessageType =
   | 'livereload'
   | 'resize'
   | 'openModal'
-  | 'closeModal';
+  | 'closeModal'
+  | 'agentWorks';
 
 export interface BaseMessage {
   type: MessageType;
@@ -277,6 +278,47 @@ export interface BroadcastMessage<PAYLOAD = unknown> extends BaseMessage {
   payload: PAYLOAD;
 }
 
+// AgentWorks (streaming agent invocation)
+
+/**
+ * Parameters passed to an AgentWorks agent invocation. Forwarded as-is to the
+ * AgentWorks streaming API by the Falcon Console host.
+ */
+export interface AgentWorksInvokeParams {
+  [key: string]: unknown;
+}
+
+/**
+ * Request sent from the extension to the host to either start (`invoke`) or
+ * cancel (`abort`) a streaming agent invocation. A single `messageId`
+ * correlates the whole stream, so the `abort` request reuses the `messageId`
+ * of the `invoke` request it cancels.
+ */
+export interface AgentWorksRequestMessage extends BaseMessage {
+  type: 'agentWorks';
+  payload:
+    | {
+        action: 'invoke';
+        agentId: string;
+        params?: AgentWorksInvokeParams;
+      }
+    | {
+        action: 'abort';
+      };
+}
+
+/**
+ * One message in an agent invocation stream. Many `chunk` messages may be sent
+ * for a single `messageId`, terminated by exactly one `complete` or `error`.
+ */
+export interface AgentWorksResponseMessage extends BaseMessage {
+  type: 'agentWorks';
+  payload:
+    | { subtype: 'chunk'; data: unknown }
+    | { subtype: 'complete' }
+    | { subtype: 'error'; error: string };
+}
+
 // Livereload
 
 export interface LivereloadMessage extends BaseMessage {
@@ -387,7 +429,8 @@ export type RequestMessage =
   | ApiRequestMessage
   | FileUploadRequestMessage
   | LogscaleRequestMessage
-  | OpenModalRequestMessage;
+  | OpenModalRequestMessage
+  | AgentWorksRequestMessage;
 
 export { ApiIdentifier };
 
@@ -401,7 +444,8 @@ export type ResponseMessage<DATA extends LocalData = LocalData> =
   | CollectionResponseMessage
   | LivereloadMessage
   | LogscaleResponseMessage
-  | OpenModalResponseMessage;
+  | OpenModalResponseMessage
+  | AgentWorksResponseMessage;
 
 import type { ResponseFor as ApiResponseFor } from './apis/types-response-for';
 
@@ -420,7 +464,9 @@ type ResponseFor<
           ? FileUploadResponseMessage<FILEUPLOADTYPE>
           : REQ extends OpenModalRequestMessage
             ? OpenModalResponseMessage
-            : ApiResponseFor<REQ>;
+            : REQ extends AgentWorksRequestMessage
+              ? AgentWorksResponseMessage
+              : ApiResponseFor<REQ>;
 
 export { ResponseFor };
 

--- a/tests/abstraction/agent-works.test.ts
+++ b/tests/abstraction/agent-works.test.ts
@@ -138,6 +138,21 @@ test('it ignores chunks received after the stream finishes', async () => {
   expect(chunks).toEqual([]);
 });
 
+test('it ignores chunks received after an error', async () => {
+  const pending = captureInvocation();
+  const stream = api.agentWorks.invoke('agent-1');
+  const { messageId } = await pending;
+
+  const chunks: unknown[] = [];
+  stream.on('data', (chunk) => chunks.push(chunk));
+
+  sendFromHost(messageId, { subtype: 'error', error: 'boom' });
+  sendFromHost(messageId, { subtype: 'chunk', data: 'late' });
+  await nextTick();
+
+  expect(chunks).toEqual([]);
+});
+
 test('abort sends an abort message and emits end', async () => {
   const pending = captureInvocation();
   const stream: AgentStream = api.agentWorks.invoke('agent-1');

--- a/tests/abstraction/agent-works.test.ts
+++ b/tests/abstraction/agent-works.test.ts
@@ -1,0 +1,190 @@
+import FalconApi from '../../src/';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { connectApi, nextTick } from '../helpers';
+
+import type { AgentStream } from '../../src/abstraction/agent-works';
+import type {
+  AgentWorksRequestMessage,
+  AgentWorksResponseMessage,
+  MessageEnvelope,
+} from '../../src/types';
+
+let api: FalconApi;
+
+beforeEach(async () => {
+  api = new FalconApi();
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  window.parent = new Window();
+
+  await connectApi(api);
+});
+
+afterEach(() => {
+  api.destroy();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Listen for the next outgoing agentWorks request and return its messageId, so
+ * tests can simulate host responses correlated to the invocation.
+ */
+function captureInvocation(): Promise<{ messageId: string }> {
+  return new Promise((resolve) => {
+    window.parent.addEventListener(
+      'message',
+      (event: MessageEvent<MessageEnvelope<AgentWorksRequestMessage>>) => {
+        if (event.data.message.type === 'agentWorks') {
+          resolve({ messageId: event.data.meta.messageId });
+        }
+      },
+      { once: true },
+    );
+  });
+}
+
+/** Simulate the host sending one stream message back to the extension. */
+function sendFromHost(
+  messageId: string,
+  payload: AgentWorksResponseMessage['payload'],
+) {
+  const response: MessageEnvelope<AgentWorksResponseMessage> = {
+    message: { type: 'agentWorks', payload },
+    meta: { messageId },
+  };
+
+  window.postMessage(response);
+}
+
+test('it sends an invoke request with the agent id and params', async () => {
+  const spy = vi.spyOn(window.parent, 'postMessage');
+
+  api.agentWorks.invoke('agent-1', { prompt: 'hello' });
+
+  expect(spy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      message: {
+        type: 'agentWorks',
+        payload: {
+          action: 'invoke',
+          agentId: 'agent-1',
+          params: { prompt: 'hello' },
+        },
+      },
+    }),
+    expect.anything(),
+  );
+});
+
+test('it emits data events for each chunk, in order', async () => {
+  const pending = captureInvocation();
+  const stream = api.agentWorks.invoke('agent-1');
+  const { messageId } = await pending;
+
+  const chunks: unknown[] = [];
+  stream.on('data', (chunk) => chunks.push(chunk));
+
+  sendFromHost(messageId, { subtype: 'chunk', data: 'a' });
+  sendFromHost(messageId, { subtype: 'chunk', data: 'b' });
+  sendFromHost(messageId, { subtype: 'chunk', data: 'c' });
+  await nextTick();
+
+  expect(chunks).toEqual(['a', 'b', 'c']);
+});
+
+test('it emits end on complete', async () => {
+  const pending = captureInvocation();
+  const stream = api.agentWorks.invoke('agent-1');
+  const { messageId } = await pending;
+
+  const ended = vi.fn();
+  stream.on('end', ended);
+
+  sendFromHost(messageId, { subtype: 'chunk', data: 'a' });
+  sendFromHost(messageId, { subtype: 'complete' });
+  await nextTick();
+
+  expect(ended).toHaveBeenCalledOnce();
+});
+
+test('it emits an Error on error subtype', async () => {
+  const pending = captureInvocation();
+  const stream = api.agentWorks.invoke('agent-1');
+  const { messageId } = await pending;
+
+  const errors: Error[] = [];
+  stream.on('error', (err) => errors.push(err));
+
+  sendFromHost(messageId, { subtype: 'error', error: 'boom' });
+  await nextTick();
+
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toBeInstanceOf(Error);
+  expect(errors[0].message).toBe('boom');
+});
+
+test('it ignores chunks received after the stream finishes', async () => {
+  const pending = captureInvocation();
+  const stream = api.agentWorks.invoke('agent-1');
+  const { messageId } = await pending;
+
+  const chunks: unknown[] = [];
+  stream.on('data', (chunk) => chunks.push(chunk));
+
+  sendFromHost(messageId, { subtype: 'complete' });
+  sendFromHost(messageId, { subtype: 'chunk', data: 'late' });
+  await nextTick();
+
+  expect(chunks).toEqual([]);
+});
+
+test('abort sends an abort message and emits end', async () => {
+  const pending = captureInvocation();
+  const stream: AgentStream = api.agentWorks.invoke('agent-1');
+  const { messageId } = await pending;
+
+  const ended = vi.fn();
+  stream.on('end', ended);
+
+  const spy = vi.spyOn(window.parent, 'postMessage');
+  stream.abort();
+
+  expect(spy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      message: { type: 'agentWorks', payload: { action: 'abort' } },
+      meta: expect.objectContaining({ messageId }),
+    }),
+    expect.anything(),
+  );
+  await nextTick();
+  expect(ended).toHaveBeenCalledOnce();
+});
+
+test('abort is idempotent and stops further chunks', async () => {
+  const pending = captureInvocation();
+  const stream = api.agentWorks.invoke('agent-1');
+  const { messageId } = await pending;
+
+  const chunks: unknown[] = [];
+  stream.on('data', (chunk) => chunks.push(chunk));
+
+  stream.abort();
+  stream.abort();
+
+  sendFromHost(messageId, { subtype: 'chunk', data: 'late' });
+  await nextTick();
+
+  expect(chunks).toEqual([]);
+});
+
+test('destroy aborts open streams', async () => {
+  const pending = captureInvocation();
+  const stream = api.agentWorks.invoke('agent-1');
+  await pending;
+
+  const abortSpy = vi.spyOn(stream, 'abort');
+
+  api.destroy();
+
+  expect(abortSpy).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

  Adds a new `agentWorks` API to Foundry-JS for invoking AgentWorks agents and consuming their responses as a stream. Unlike the existing request/response bridge calls that resolve to a single payload, agent invocations stream many chunks over a single message correlation ID, terminated by a `complete` or `error`.

## What's included

  - **`AgentWorks` / `AgentStream` abstraction** (`src/abstraction/agent-works.ts`) — `api.agentWorks.invoke(agentId, params)`
  returns an `AgentStream` that emits:
    - `data` — each chunk as it arrives
    - `end` — stream completed successfully
    - `error` — stream terminated with an error

    Streams support `on()`/`off()` subscription and `abort()` to cancel an in-flight invocation. The parent `AgentWorks`
  instance tracks open streams and tears them all down on `destroy()`.

  - **Streaming bridge primitives** (`src/bridge.ts`) — adds `openStream()` and `sendStreamMessage()`. Unlike `postMessage()`, a stream subscription is *not* removed after the first response; it persists for the lifetime of the stream and is removed via the returned `close()` once the stream completes, errors, or is aborted. No timeout is applied since streams can run for arbitrary durations. The `abort` request reuses the original `invoke` message ID to correlate the cancellation.

  - **Message types** (`src/types.ts`) — adds the `agentWorks` message type, `AgentWorksInvokeParams`,
  `AgentWorksRequestMessage` (`invoke` / `abort`), and `AgentWorksResponseMessage` (`chunk` / `complete` / `error`), wired into
  the `RequestMessage`/`ResponseMessage` unions and `ResponseFor` mapping.

  - **Public exports** (`src/index.ts`) — exports `AgentWorks` and `AgentStream`.

  - **Docs & tests** — new README section under "Working with AgentWorks" and unit tests in
  `tests/abstraction/agent-works.test.ts`.

  ## Usage

  ```javascript
  const stream = falcon.agentWorks.invoke('<agent-id>', { prompt: 'Summarize this detection' });

  stream.on('data', (chunk) => {
    // append chunk to your UI
  });

  stream.on('end', () => {
    // finalize output
  });

  stream.on('error', (err) => {
    // handle err.message
  });

  // cancel an in-flight stream early
  stream.abort();
```